### PR TITLE
Fix loading crashes from empty lists

### DIFF
--- a/src/ArenaGS.Tests/SaveLoadTests.cs
+++ b/src/ArenaGS.Tests/SaveLoadTests.cs
@@ -27,7 +27,8 @@ namespace ArenaGS.Tests
 			Assert.AreEqual (state.Player.Position, newState.Player.Position);
 			Assert.AreEqual (state.Map.Width, newState.Map.Width);
 			Assert.AreEqual (state.Map.Height, newState.Map.Height);
-			Assert.AreEqual (state.Enemies.Count, state.Enemies.Count);
+			Assert.AreEqual (state.Enemies.Count, newState.Enemies.Count);
+			Assert.AreEqual (state.LogEntries.Count, newState.LogEntries.Count);
 
 			Assert.IsFalse (Serialization.SaveGameExists);
 		}

--- a/src/ArenaGS/GameState.cs
+++ b/src/ArenaGS/GameState.cs
@@ -49,6 +49,16 @@ namespace ArenaGS
 			return new GameState (this) { Map = map };
 		}
 
+		internal GameState WithEnemies (ImmutableList<Character> enemies)
+		{
+			return new GameState (this) { Enemies = enemies };
+		}
+
+		internal GameState WithLog (ImmutableList<string> logEntries)
+		{
+			return new GameState (this) { LogEntries = logEntries };
+		}
+
 		internal GameState WithNewLogLine (string line)
 		{
 			var logBuilder = LogEntries.ToBuilder ();

--- a/src/ArenaGS/Utilities/Serialization.cs
+++ b/src/ArenaGS/Utilities/Serialization.cs
@@ -2,6 +2,7 @@
 using ArenaGS.Platform;
 using ProtoBuf;
 using ArenaGS.Model;
+using System.Collections.Immutable;
 
 namespace ArenaGS.Utilities
 {
@@ -63,7 +64,17 @@ namespace ArenaGS.Utilities
 				Map savedStubMap = container.State.Map;
 				var worldGenerator = Dependencies.Get<IWorldGenerator> ();
 				Map map = worldGenerator.GetMapGenerator (savedStubMap.MapType).Regenerate (savedStubMap.Hash);
-				return container.State.WithMap (map);
+				GameState state = container.State.WithMap (map);
+
+				// Protobuffer serializes empty lists as null
+				// For each list in state, we must instead give an empty list
+				// Else NRE will occur on use
+				if (state.Enemies == null)
+					state = state.WithEnemies (ImmutableList<Character>.Empty);
+				if (state.LogEntries == null)
+					state = state.WithLog (ImmutableList<string>.Empty);
+
+				return state;
 			}
 		}
 	}


### PR DESCRIPTION
- Protobuf serialized lists as null, which is not super helpful
- Fix up, and extend test to catch