### PR TITLE
Implement the point (of the sword) with combat stats, dead, and storytelling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,7 @@ dependencies = [
  "derive_is_enum_variant",
  "enum-iterator",
  "lazy_static",
+ "leak",
  "line_drawing",
  "num-derive",
  "num-traits 0.2.12",
@@ -257,6 +258,12 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "leak"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd100e01f1154f2908dfa7d02219aeab25d0b9c7fa955164192e3245255a0c73"
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ lazy_static = "1.4.0"
 line_drawing = "0.8.0"
 ordered-float = "2.0.0"
 assert_approx_eq = "1.1.0"
+leak = "0.1.2"
 
 [dependencies.sdl2]
 version = "0.32.1"

--- a/TODO.md
+++ b/TODO.md
@@ -1,2 +1,2 @@
-- When character life gone, remove. Setup fail state and repeat state (for now)
-- Movement Speed (how much of a turn do you spend moving one square)
+- Restart scene on player OR all enemy death
+   - Create a storyteller component which detects and determins what to do 

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-- Defense (Dodge, Armor, Absorb)
-   - Should dodge not regain over time by by character movement? 
+
+- Should dodge not regain over time by by character movement? 
 - When character life gone, remove. Setup fail state and repeat state (for now)
 - Movement Speed (how much of a turn do you spend moving one square)

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,7 @@
+- RandomComponent (with save load)
+- Dice
+- Damage (1/2 dice fixed)
+- Defense (Dodge, Armor, Absorb)
+   - Should dodge not regain over time by by character movement? 
+- When character life gone, remove. Setup fail state and repeat state (for now)
+- Movement Speed (how much of a turn do you spend moving one square)

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,2 @@
-- skills have strength
 - When character life gone, remove. Setup fail state and repeat state (for now)
 - Movement Speed (how much of a turn do you spend moving one square)

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,3 @@
-- RandomComponent (with save load)
 - Dice
 - Damage (1/2 dice fixed)
 - Defense (Dodge, Armor, Absorb)

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,3 @@
-- Dice
-- Damage (1/2 dice fixed)
 - Defense (Dodge, Armor, Absorb)
    - Should dodge not regain over time by by character movement? 
 - When character life gone, remove. Setup fail state and repeat state (for now)

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,3 @@
-- Regain dodge via movement
 - skills have strength
 - When character life gone, remove. Setup fail state and repeat state (for now)
 - Movement Speed (how much of a turn do you spend moving one square)

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-
-- Should dodge not regain over time by by character movement? 
+- Regain dodge via movement
+- skills have strength
 - When character life gone, remove. Setup fail state and repeat state (for now)
 - Movement Speed (how much of a turn do you spend moving one square)

--- a/TODO.md
+++ b/TODO.md
@@ -1,2 +1,0 @@
-- Restart scene on player OR all enemy death
-   - Create a storyteller component which detects and determins what to do 

--- a/src/after_image.rs
+++ b/src/after_image.rs
@@ -11,6 +11,6 @@ mod sprites;
 mod text_renderer;
 
 pub use image_loader::load_image;
-pub use render_context::{FontContext, RenderContext};
+pub use render_context::{FontContext, RenderContext, RenderContextHolder};
 pub use sprites::{Background, Bolt, CharacterAnimationState, DetailedCharacter, LargeEnemy, Sprite, SpriteFolderDescription};
 pub use text_renderer::{FontColor, FontSize, TextRenderer};

--- a/src/after_image/render_context.rs
+++ b/src/after_image/render_context.rs
@@ -1,3 +1,5 @@
+use std::{cell::RefCell, rc::Rc};
+
 use sdl2::image::{self, InitFlag};
 
 pub struct FontContext {
@@ -10,6 +12,8 @@ impl FontContext {
         Ok(FontContext { ttf_context })
     }
 }
+
+pub type RenderContextHolder = Rc<RefCell<RenderContext>>;
 
 pub struct RenderContext {
     _image_context: sdl2::image::Sdl2ImageContext,

--- a/src/after_image/text_renderer.rs
+++ b/src/after_image/text_renderer.rs
@@ -19,14 +19,21 @@ pub enum FontColor {
     Red,
 }
 
-pub struct TextRenderer<'a> {
-    small_font: sdl2::ttf::Font<'a, 'a>,
-    bold_font: sdl2::ttf::Font<'a, 'a>,
-    large_font: sdl2::ttf::Font<'a, 'a>,
+// So this is either a beautiful hack, or an abuse
+// The SDL font code wants two lifetimes, which requires
+// TextRenderer to have a lifeime, which causes a bunch
+// of other classes to require lifetime
+// By just leaking the fonts, which last the lifetime of
+// the game, all of this goes away.
+// This is safe, right?!?
+pub struct TextRenderer {
+    small_font: sdl2::ttf::Font<'static, 'static>,
+    bold_font: sdl2::ttf::Font<'static, 'static>,
+    large_font: sdl2::ttf::Font<'static, 'static>,
 }
 
-impl<'a> TextRenderer<'a> {
-    pub fn init(font_context: &'a FontContext) -> BoxResult<TextRenderer> {
+impl TextRenderer {
+    pub fn init(font_context: &'static FontContext) -> BoxResult<TextRenderer> {
         let font_path = Path::new(&get_exe_folder()).join("fonts").join("LibreFranklin-Regular.ttf");
 
         let mut small_font = font_context.ttf_context.load_font(font_path.clone(), 14)?;

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -25,3 +25,6 @@ pub use components::add_ui_extension;
 
 mod saveload;
 mod spawner;
+
+mod arena_storyteller;
+pub use arena_storyteller::ArenaStoryteller;

--- a/src/arena/arena_storyteller.rs
+++ b/src/arena/arena_storyteller.rs
@@ -1,6 +1,9 @@
 use std::rc::Rc;
 
+use specs::prelude::*;
+
 use crate::after_image::{RenderCanvas, RenderContextHolder, TextRenderer};
+use crate::clash::PlayerDeadComponent;
 use crate::conductor::{EventStatus, Scene, Storyteller};
 
 use super::BattleScene;
@@ -20,7 +23,10 @@ impl ArenaStoryteller {
 }
 
 impl Storyteller for ArenaStoryteller {
-    fn check_place(&self) -> EventStatus {
+    fn check_place(&self, ecs: &World) -> EventStatus {
+        if ecs.try_fetch::<PlayerDeadComponent>().is_some() {
+            return EventStatus::NewScene(self.initial_scene());
+        }
         EventStatus::Continue
     }
 

--- a/src/arena/arena_storyteller.rs
+++ b/src/arena/arena_storyteller.rs
@@ -1,0 +1,30 @@
+use std::rc::Rc;
+
+use crate::after_image::{RenderCanvas, RenderContextHolder, TextRenderer};
+use crate::conductor::{EventStatus, Scene, Storyteller};
+
+use super::BattleScene;
+
+pub struct ArenaStoryteller {
+    render_context: RenderContextHolder,
+    text_renderer: Rc<TextRenderer>,
+}
+
+impl ArenaStoryteller {
+    pub fn init(render_context_holder: &RenderContextHolder, text_renderer: &Rc<TextRenderer>) -> ArenaStoryteller {
+        ArenaStoryteller {
+            render_context: Rc::clone(render_context_holder),
+            text_renderer: Rc::clone(&text_renderer),
+        }
+    }
+}
+
+impl Storyteller for ArenaStoryteller {
+    fn check_place(&self) -> EventStatus {
+        EventStatus::Continue
+    }
+
+    fn initial_scene(&self) -> Box<dyn Scene> {
+        Box::new(BattleScene::init(&self.render_context, &self.text_renderer).unwrap())
+    }
+}

--- a/src/arena/arena_storyteller.rs
+++ b/src/arena/arena_storyteller.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 
 use specs::prelude::*;
 
-use crate::after_image::{RenderCanvas, RenderContextHolder, TextRenderer};
+use crate::after_image::{RenderContextHolder, TextRenderer};
 use crate::clash::{CharacterInfoComponent, PlayerComponent, PlayerDeadComponent};
 use crate::conductor::{EventStatus, Scene, Storyteller};
 

--- a/src/arena/battle_animations.rs
+++ b/src/arena/battle_animations.rs
@@ -131,9 +131,9 @@ fn animate_move(ecs: &mut World, target: Entity) {
     let frame = ecs.get_current_frame();
     let position = ecs.get_position(&target);
 
-    let animation = Animation::movement(position.origin, new_position.origin, frame, MOVE_LENGTH);
+    let animation =
+        Animation::movement(position.origin, new_position.origin, frame, MOVE_LENGTH).with_post_event(EventKind::Move(MoveState::Complete), Some(target));
     ecs.shovel(target, AnimationComponent::init(animation));
-    ecs.raise_event(EventKind::Move(MoveState::Complete), Some(target));
 }
 
 pub fn explode_event(ecs: &mut World, kind: EventKind, target: Option<Entity>) {

--- a/src/arena/battle_animations.rs
+++ b/src/arena/battle_animations.rs
@@ -10,8 +10,8 @@ use crate::clash::*;
 pub fn bolt_event(ecs: &mut World, kind: EventKind, target: Option<Entity>) {
     match kind {
         EventKind::Bolt(state) => match state {
-            BoltState::BeginCast => begin_ranged_cast_animation(ecs, target.unwrap()),
-            BoltState::BeginFlying => begin_ranged_bolt_animation(ecs, target.unwrap()),
+            BoltState::BeginCastAnimation => begin_ranged_cast_animation(ecs, target.unwrap()),
+            BoltState::BeginFlyingAnimation => begin_ranged_bolt_animation(ecs, target.unwrap()),
             _ => {}
         },
         _ => {}
@@ -49,7 +49,7 @@ pub fn begin_ranged_cast_animation(ecs: &mut World, target: Entity) {
         }
     };
 
-    cast_animation(ecs, target, animation, EventKind::Bolt(BoltState::CompleteCast));
+    cast_animation(ecs, target, animation, EventKind::Bolt(BoltState::CompleteCastAnimation));
 }
 
 pub fn begin_ranged_bolt_animation(ecs: &mut World, bolt: Entity) {
@@ -60,14 +60,14 @@ pub fn begin_ranged_bolt_animation(ecs: &mut World, bolt: Entity) {
             BoltKind::Bullet => SpriteKinds::BulletBolt,
         }
     };
-    projectile_animation(ecs, bolt, sprite, EventKind::Bolt(BoltState::CompleteFlying));
+    projectile_animation(ecs, bolt, sprite, EventKind::Bolt(BoltState::CompleteFlyingAnimation));
 }
 
 pub fn field_event(ecs: &mut World, kind: EventKind, target: Option<Entity>) {
     match kind {
         EventKind::Field(state) => match state {
-            FieldState::BeginCast => begin_ranged_cast_field_animation(ecs, target.unwrap()),
-            FieldState::BeginFlying => begin_ranged_field_animation(ecs, target.unwrap()),
+            FieldState::BeginCastAnimation => begin_ranged_cast_field_animation(ecs, target.unwrap()),
+            FieldState::BeginFlyingAnimation => begin_ranged_field_animation(ecs, target.unwrap()),
             _ => {}
         },
         _ => {}
@@ -81,7 +81,7 @@ pub fn begin_ranged_cast_field_animation(ecs: &mut World, target: Entity) {
             FieldKind::Fire => CharacterAnimationState::Crouch,
         }
     };
-    cast_animation(ecs, target, animation, EventKind::Field(FieldState::CompleteCast));
+    cast_animation(ecs, target, animation, EventKind::Field(FieldState::CompleteCastAnimation));
 }
 
 pub fn begin_ranged_field_animation(ecs: &mut World, bolt: Entity) {
@@ -91,11 +91,11 @@ pub fn begin_ranged_field_animation(ecs: &mut World, bolt: Entity) {
             FieldKind::Fire => SpriteKinds::Bomb,
         }
     };
-    projectile_animation(ecs, bolt, sprite, EventKind::Field(FieldState::CompleteFlying));
+    projectile_animation(ecs, bolt, sprite, EventKind::Field(FieldState::CompleteFlyingAnimation));
 }
 
 pub fn melee_event(ecs: &mut World, kind: EventKind, target: Option<Entity>) {
-    if matches!(kind, EventKind::Melee(state) if state.is_begin()) {
+    if matches!(kind, EventKind::Melee(state) if state.is_begin_animation()) {
         begin_melee_animation(ecs, target.unwrap());
     }
 }
@@ -111,12 +111,12 @@ pub fn begin_melee_animation(ecs: &mut World, target: Entity) {
 
     const MELEE_ATTACK_LENGTH: u64 = 18;
     let attack_animation = Animation::sprite_state(animation, CharacterAnimationState::Idle, frame, MELEE_ATTACK_LENGTH)
-        .with_post_event(EventKind::Melee(MeleeState::Complete), Some(target));
+        .with_post_event(EventKind::Melee(MeleeState::CompleteAnimation), Some(target));
     ecs.shovel(target, AnimationComponent::init(attack_animation));
 }
 
 pub fn move_event(ecs: &mut World, kind: EventKind, target: Option<Entity>) {
-    if matches!(kind, EventKind::Move(state) if state.is_begin()) {
+    if matches!(kind, EventKind::Move(state) if state.is_begin_animation()) {
         animate_move(ecs, target.unwrap());
     }
 }
@@ -131,13 +131,13 @@ fn animate_move(ecs: &mut World, target: Entity) {
     let frame = ecs.get_current_frame();
     let position = ecs.get_position(&target);
 
-    let animation =
-        Animation::movement(position.origin, new_position.origin, frame, MOVE_LENGTH).with_post_event(EventKind::Move(MoveState::Complete), Some(target));
+    let animation = Animation::movement(position.origin, new_position.origin, frame, MOVE_LENGTH)
+        .with_post_event(EventKind::Move(MoveState::CompleteAnimation), Some(target));
     ecs.shovel(target, AnimationComponent::init(animation));
 }
 
 pub fn explode_event(ecs: &mut World, kind: EventKind, target: Option<Entity>) {
-    if matches!(kind, EventKind::Explode(state) if state.is_begin()) {
+    if matches!(kind, EventKind::Explode(state) if state.is_begin_animation()) {
         begin_explode_animation(ecs, target.unwrap());
     }
 }
@@ -148,6 +148,6 @@ pub fn begin_explode_animation(ecs: &mut World, target: Entity) {
     ecs.write_storage::<FieldComponent>().remove(target);
 
     const EXPLOSION_LENGTH: u64 = 18;
-    let attack_animation = Animation::empty(frame, EXPLOSION_LENGTH).with_post_event(EventKind::Explode(ExplodeState::Complete), Some(target));
+    let attack_animation = Animation::empty(frame, EXPLOSION_LENGTH).with_post_event(EventKind::Explode(ExplodeState::CompleteAnimation), Some(target));
     ecs.shovel(target, AnimationComponent::init(attack_animation));
 }

--- a/src/arena/battle_scene.rs
+++ b/src/arena/battle_scene.rs
@@ -63,14 +63,6 @@ impl BattleScene {
             Keycode::Left => battle_actions::move_action(&mut self.ecs, Direction::West),
             Keycode::Right => battle_actions::move_action(&mut self.ecs, Direction::East),
             Keycode::S => saveload::save(&mut self.ecs),
-            Keycode::D => {
-                self.ecs
-                    .write_storage::<CharacterInfoComponent>()
-                    .grab_mut(find_player(&self.ecs))
-                    .character
-                    .defenses
-                    .health = 0
-            }
             Keycode::L => {
                 if let Ok(new_world) = saveload::load() {
                     self.ecs = new_world;

--- a/src/arena/battle_scene.rs
+++ b/src/arena/battle_scene.rs
@@ -215,6 +215,10 @@ impl Scene for BattleScene {
 
         Ok(())
     }
+
+    fn get_state(&self) -> &World {
+        &self.ecs
+    }
 }
 
 pub fn process_tick_events(ecs: &mut World, frame: u64) {

--- a/src/arena/battle_scene.rs
+++ b/src/arena/battle_scene.rs
@@ -218,7 +218,10 @@ impl<'a> Scene for BattleScene<'a> {
 
 pub fn process_tick_events(ecs: &mut World, frame: u64) {
     ecs.maintain();
-    tick_animations(ecs, frame);
+    if ecs.try_fetch::<PlayerDeadComponent>().is_none() {
+        tick_animations(ecs, frame);
+        reap_killed(ecs);
+    }
 }
 
 fn is_keystroke_skill(keycode: Keycode) -> Option<u32> {

--- a/src/arena/battle_scene.rs
+++ b/src/arena/battle_scene.rs
@@ -13,7 +13,7 @@ use crate::clash::*;
 
 use super::saveload;
 use crate::after_image::{RenderCanvas, RenderContextHolder, TextRenderer};
-use crate::atlas::{BoxResult, EasyMutECS, Point};
+use crate::atlas::{BoxResult, Point};
 use crate::conductor::Scene;
 
 pub struct BattleScene {

--- a/src/arena/saveload.rs
+++ b/src/arena/saveload.rs
@@ -95,6 +95,7 @@ pub fn save(ecs: &mut World) {
         MovementComponent,
         SkillResourceComponent,
         BehaviorComponent,
+        PlayerDeadComponent,
         SerializationHelper
     );
 }
@@ -132,6 +133,7 @@ pub fn load() -> BoxResult<World> {
             MovementComponent,
             SkillResourceComponent,
             BehaviorComponent,
+            PlayerDeadComponent,
             SerializationHelper
         );
     }

--- a/src/arena/spawner.rs
+++ b/src/arena/spawner.rs
@@ -16,7 +16,7 @@ pub fn player(ecs: &mut World) {
             CharacterAnimationState::Idle,
         )))
         .with(PositionComponent::init(SizedPoint::init(4, 4)))
-        .with(CharacterInfoComponent::init(Character::init()))
+        .with(CharacterInfoComponent::init(Character::init(Defenses::init(0, 0, 0, 10))))
         .with(PlayerComponent::init())
         .with(TimeComponent::init(0))
         .with(SkillResourceComponent::init(&[(AmmoKind::Bullets, 6)]).with_focus(1.0))
@@ -29,7 +29,7 @@ pub fn bird_monster(ecs: &mut World) {
     ecs.create_entity()
         .with(RenderComponent::init(RenderInfo::init(SpriteKinds::MonsterBirdBrown)))
         .with(PositionComponent::init(SizedPoint::init_multi(5, 5, 2, 2)))
-        .with(CharacterInfoComponent::init(Character::init()))
+        .with(CharacterInfoComponent::init(Character::init(Defenses::init(0, 0, 0, 25))))
         .with(BehaviorComponent::init(BehaviorKind::Random))
         .with(TimeComponent::init(0))
         .marked::<SimpleMarker<ToSerialize>>()

--- a/src/arena/spawner.rs
+++ b/src/arena/spawner.rs
@@ -16,7 +16,7 @@ pub fn player(ecs: &mut World) {
             CharacterAnimationState::Idle,
         )))
         .with(PositionComponent::init(SizedPoint::init(4, 4)))
-        .with(CharacterInfoComponent::init(Character::init(Defenses::init(0, 0, 0, 10))))
+        .with(CharacterInfoComponent::init(Character::init(Defenses::init(0, 0, 0, 0, 10))))
         .with(PlayerComponent::init())
         .with(TimeComponent::init(0))
         .with(SkillResourceComponent::init(&[(AmmoKind::Bullets, 6)]).with_focus(1.0))
@@ -29,7 +29,7 @@ pub fn bird_monster(ecs: &mut World) {
     ecs.create_entity()
         .with(RenderComponent::init(RenderInfo::init(SpriteKinds::MonsterBirdBrown)))
         .with(PositionComponent::init(SizedPoint::init_multi(5, 5, 2, 2)))
-        .with(CharacterInfoComponent::init(Character::init(Defenses::init(0, 0, 0, 25))))
+        .with(CharacterInfoComponent::init(Character::init(Defenses::init(0, 0, 0, 0, 25))))
         .with(BehaviorComponent::init(BehaviorKind::Random))
         .with(TimeComponent::init(0))
         .marked::<SimpleMarker<ToSerialize>>()

--- a/src/arena/spawner.rs
+++ b/src/arena/spawner.rs
@@ -16,7 +16,7 @@ pub fn player(ecs: &mut World) {
             CharacterAnimationState::Idle,
         )))
         .with(PositionComponent::init(SizedPoint::init(4, 4)))
-        .with(CharacterInfoComponent::init(Character::init(Defenses::init(0, 0, 0, 0, 10))))
+        .with(CharacterInfoComponent::init(CharacterInfo::init(Defenses::init(0, 0, 0, 0, 10))))
         .with(PlayerComponent::init())
         .with(TimeComponent::init(0))
         .with(SkillResourceComponent::init(&[(AmmoKind::Bullets, 6)]).with_focus(1.0))
@@ -29,7 +29,7 @@ pub fn bird_monster(ecs: &mut World) {
     ecs.create_entity()
         .with(RenderComponent::init(RenderInfo::init(SpriteKinds::MonsterBirdBrown)))
         .with(PositionComponent::init(SizedPoint::init_multi(5, 5, 2, 2)))
-        .with(CharacterInfoComponent::init(Character::init(Defenses::init(0, 0, 0, 0, 25))))
+        .with(CharacterInfoComponent::init(CharacterInfo::init(Defenses::init(0, 0, 0, 0, 25))))
         .with(BehaviorComponent::init(BehaviorKind::Random))
         .with(TimeComponent::init(0))
         .marked::<SimpleMarker<ToSerialize>>()

--- a/src/arena/views/debug.rs
+++ b/src/arena/views/debug.rs
@@ -15,11 +15,11 @@ use crate::clash::MAX_MAP_TILES;
 
 pub struct DebugView<'a> {
     position: SDLPoint,
-    text: &'a TextRenderer<'a>,
+    text: &'a TextRenderer,
 }
 
 impl<'a> DebugView<'a> {
-    pub fn init(position: SDLPoint, text: &'a TextRenderer<'a>) -> BoxResult<DebugView> {
+    pub fn init(position: SDLPoint, text: &'a TextRenderer) -> BoxResult<DebugView> {
         Ok(DebugView { position, text })
     }
 }

--- a/src/arena/views/debug.rs
+++ b/src/arena/views/debug.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use sdl2::pixels::Color;
 use sdl2::rect::Point as SDLPoint;
 use sdl2::rect::Rect as SDLRect;
@@ -13,18 +15,18 @@ use crate::clash::MapComponent;
 
 use crate::clash::MAX_MAP_TILES;
 
-pub struct DebugView<'a> {
+pub struct DebugView {
     position: SDLPoint,
-    text: &'a TextRenderer,
+    text: Rc<TextRenderer>,
 }
 
-impl<'a> DebugView<'a> {
-    pub fn init(position: SDLPoint, text: &'a TextRenderer) -> BoxResult<DebugView> {
+impl DebugView {
+    pub fn init(position: SDLPoint, text: Rc<TextRenderer>) -> BoxResult<DebugView> {
         Ok(DebugView { position, text })
     }
 }
 
-impl<'a> View for DebugView<'a> {
+impl View for DebugView {
     fn render(&self, ecs: &World, canvas: &mut RenderCanvas, _frame: u64) -> BoxResult<()> {
         if let BattleSceneState::Debug(kind) = battle_actions::read_state(&ecs) {
             let state = format!("Debug: {}", kind.to_string());

--- a/src/arena/views/infobar.rs
+++ b/src/arena/views/infobar.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use enum_iterator::IntoEnumIterator;
 use sdl2::pixels::Color;
 use sdl2::rect::Point as SDLPoint;
@@ -9,13 +11,13 @@ use crate::after_image::{FontColor, FontSize, RenderCanvas, TextRenderer};
 use crate::atlas::{BoxResult, EasyECS};
 use crate::clash::{find_player, AmmoKind, SkillResourceComponent};
 
-pub struct InfoBarView<'a> {
+pub struct InfoBarView {
     position: SDLPoint,
-    text: &'a TextRenderer,
+    text: Rc<TextRenderer>,
 }
 
-impl<'a> InfoBarView<'a> {
-    pub fn init(position: SDLPoint, text: &'a TextRenderer) -> BoxResult<InfoBarView> {
+impl InfoBarView {
+    pub fn init(position: SDLPoint, text: Rc<TextRenderer>) -> BoxResult<InfoBarView> {
         Ok(InfoBarView { position, text })
     }
     fn render_character_info(&self, ecs: &World, canvas: &mut RenderCanvas) -> BoxResult<()> {
@@ -62,7 +64,7 @@ impl<'a> InfoBarView<'a> {
     }
 }
 
-impl<'a> View for InfoBarView<'a> {
+impl View for InfoBarView {
     fn render(&self, ecs: &World, canvas: &mut RenderCanvas, _frame: u64) -> BoxResult<()> {
         canvas.set_draw_color(Color::from((196, 196, 0)));
         canvas.fill_rect(SDLRect::new(self.position.x, self.position.y, 230, 400))?;

--- a/src/arena/views/infobar.rs
+++ b/src/arena/views/infobar.rs
@@ -11,11 +11,11 @@ use crate::clash::{find_player, AmmoKind, SkillResourceComponent};
 
 pub struct InfoBarView<'a> {
     position: SDLPoint,
-    text: &'a TextRenderer<'a>,
+    text: &'a TextRenderer,
 }
 
 impl<'a> InfoBarView<'a> {
-    pub fn init(position: SDLPoint, text: &'a TextRenderer<'a>) -> BoxResult<InfoBarView> {
+    pub fn init(position: SDLPoint, text: &'a TextRenderer) -> BoxResult<InfoBarView> {
         Ok(InfoBarView { position, text })
     }
     fn render_character_info(&self, ecs: &World, canvas: &mut RenderCanvas) -> BoxResult<()> {

--- a/src/arena/views/log.rs
+++ b/src/arena/views/log.rs
@@ -12,11 +12,11 @@ const LOG_COUNT: usize = 10;
 
 pub struct LogView<'a> {
     position: SDLPoint,
-    text: &'a TextRenderer<'a>,
+    text: &'a TextRenderer,
 }
 
 impl<'a> LogView<'a> {
-    pub fn init(position: SDLPoint, text: &'a TextRenderer<'a>) -> BoxResult<LogView> {
+    pub fn init(position: SDLPoint, text: &'a TextRenderer) -> BoxResult<LogView> {
         Ok(LogView { position, text })
     }
 

--- a/src/arena/views/log.rs
+++ b/src/arena/views/log.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use sdl2::pixels::Color;
 use sdl2::rect::Point as SDLPoint;
 use sdl2::rect::Rect as SDLRect;
@@ -10,13 +12,13 @@ use crate::clash::LogComponent;
 
 const LOG_COUNT: usize = 10;
 
-pub struct LogView<'a> {
+pub struct LogView {
     position: SDLPoint,
-    text: &'a TextRenderer,
+    text: Rc<TextRenderer>,
 }
 
-impl<'a> LogView<'a> {
-    pub fn init(position: SDLPoint, text: &'a TextRenderer) -> BoxResult<LogView> {
+impl LogView {
+    pub fn init(position: SDLPoint, text: Rc<TextRenderer>) -> BoxResult<LogView> {
         Ok(LogView { position, text })
     }
 
@@ -37,7 +39,7 @@ impl<'a> LogView<'a> {
     }
 }
 
-impl<'a> View for LogView<'a> {
+impl View for LogView {
     fn render(&self, ecs: &World, canvas: &mut RenderCanvas, _frame: u64) -> BoxResult<()> {
         canvas.set_draw_color(Color::from((0, 196, 196)));
         canvas.fill_rect(SDLRect::new(self.position.x, self.position.y, 230, 300))?;

--- a/src/arena/views/map.rs
+++ b/src/arena/views/map.rs
@@ -13,7 +13,7 @@ use super::{HitTestResult, View};
 use crate::after_image::{RenderCanvas, RenderContext};
 use crate::atlas::{BoxResult, Point};
 use crate::clash::{
-    element_at_location, find_player, get_skill, is_good_target, FieldComponent, MapHitTestResult, PositionComponent, Positions, SkillInfo, MAX_MAP_TILES,
+    element_at_location, find_player, get_skill, is_good_target, FieldComponent, MapHitTestResult, PositionComponent, ShortInfo, SkillInfo, MAX_MAP_TILES,
 };
 
 pub struct MapView {

--- a/src/arena/views/skillbar.rs
+++ b/src/arena/views/skillbar.rs
@@ -1,4 +1,5 @@
 use std::cmp;
+use std::rc::Rc;
 
 use sdl2::pixels::Color;
 use sdl2::rect::Point as SDLPoint;
@@ -22,9 +23,9 @@ const ICON_SIZE: i32 = 44;
 const MAX_ICON_COUNT: i32 = 10;
 
 impl SkillBarView {
-    pub fn init(render_context: &RenderContext, ecs: &World, position: SDLPoint, text: &TextRenderer) -> BoxResult<SkillBarView> {
+    pub fn init(render_context: &RenderContext, ecs: &World, position: SDLPoint, text: Rc<TextRenderer>) -> BoxResult<SkillBarView> {
         let mut views = Vec::with_capacity(15);
-        let icons = IconLoader::init(render_context, "spell")?;
+        let icons = IconLoader::init(&render_context, "spell")?;
         for i in 0..get_skill_count(ecs) {
             if let Some(skill_name) = battle_actions::get_skill_name(ecs, i as usize) {
                 let view = SkillBarItemView::init(
@@ -33,7 +34,7 @@ impl SkillBarView {
                         position.y + BORDER_WIDTH + 1,
                     ),
                     render_context,
-                    text,
+                    Rc::clone(&text),
                     &icons,
                     i as u32,
                     skill_name.as_str(),
@@ -100,18 +101,18 @@ impl SkillBarItemView {
     pub fn init(
         position: SDLPoint,
         render_context: &RenderContext,
-        text: &TextRenderer,
+        text: Rc<TextRenderer>,
         icons: &IconLoader,
         index: u32,
         skill_name: &str,
     ) -> BoxResult<SkillBarItemView> {
         let rect = SDLRect::new(position.x, position.y, 44, 44);
         let skill = get_skill(&skill_name);
-        let image = icons.get(render_context, skill.image)?;
+        let image = icons.get(&render_context, skill.image)?;
         let hotkey = text.render_texture(&render_context.canvas, &index.to_string(), FontSize::Bold, FontColor::White)?;
         let hotkey_inactive = text.render_texture(&render_context.canvas, &index.to_string(), FontSize::Bold, FontColor::Red)?;
         let alternate_image = match &skill.alternate {
-            Some(alternate) => Some(icons.get(render_context, get_skill(alternate).image)?),
+            Some(alternate) => Some(icons.get(&render_context, get_skill(alternate).image)?),
             None => None,
         };
 

--- a/src/clash.rs
+++ b/src/clash.rs
@@ -1,6 +1,6 @@
 // The game rules and logic for the games
-mod character;
-pub use character::Character;
+mod character_info;
+pub use character_info::CharacterInfo;
 
 mod skills;
 use skills::invoke_skill;

--- a/src/clash.rs
+++ b/src/clash.rs
@@ -40,3 +40,6 @@ pub use test_helpers::*;
 
 mod strength;
 pub use strength::*;
+
+mod defenses;
+pub use defenses::*;

--- a/src/clash.rs
+++ b/src/clash.rs
@@ -37,3 +37,6 @@ pub use events::*;
 mod test_helpers;
 #[cfg(test)]
 pub use test_helpers::*;
+
+mod strength;
+pub use strength::*;

--- a/src/clash/actions.rs
+++ b/src/clash/actions.rs
@@ -3,6 +3,7 @@ use specs::prelude::*;
 use super::*;
 use crate::atlas::Point;
 
+#[derive(Clone, Copy)]
 pub enum Direction {
     North,
     South,

--- a/src/clash/actions.rs
+++ b/src/clash/actions.rs
@@ -36,7 +36,7 @@ pub fn player_move(ecs: &mut World, direction: Direction) -> bool {
         point_in_direction(&position, direction)
     };
     if let Some(new_position) = new_position {
-        move_character(ecs, player, new_position);
+        move_character_action(ecs, player, new_position);
         true
     } else {
         false

--- a/src/clash/ai.rs
+++ b/src/clash/ai.rs
@@ -97,7 +97,7 @@ mod tests {
             .with(BehaviorComponent::init(BehaviorKind::Explode))
             .with(PositionComponent::init(SizedPoint::init(2, 2)))
             .with(TimeComponent::init(100))
-            .with(AttackComponent::init(Point::init(2, 2), 2, AttackKind::Explode(2)))
+            .with(AttackComponent::init(Point::init(2, 2), Damage::physical(2), AttackKind::Explode(2)))
             .build();
 
         take_enemy_action(&mut ecs, &character);

--- a/src/clash/ai.rs
+++ b/src/clash/ai.rs
@@ -92,6 +92,7 @@ mod tests {
     #[test]
     fn explode_behavior() {
         let mut ecs = create_test_state().with_character(2, 2, 0).with_map().build();
+        let target = find_at(&ecs, 2, 2);
         let character = ecs
             .create_entity()
             .with(BehaviorComponent::init(BehaviorKind::Explode))
@@ -100,10 +101,11 @@ mod tests {
             .with(AttackComponent::init(Point::init(2, 2), Damage::physical(2), AttackKind::Explode(2)))
             .build();
 
+        let starting_health = ecs.get_defenses(&target).health;
         take_enemy_action(&mut ecs, &character);
         wait_for_animations(&mut ecs);
 
         assert_eq!(0, ecs.read_storage::<BehaviorComponent>().count());
-        assert_eq!(1, ecs.read_resource::<LogComponent>().log.count());
+        assert!(ecs.get_defenses(&target).health < starting_health);
     }
 }

--- a/src/clash/ai.rs
+++ b/src/clash/ai.rs
@@ -48,7 +48,7 @@ pub fn take_enemy_action(ecs: &mut World, enemy: &Entity) {
             let position = ecs.get_position(enemy);
             if let Some(direction) = get_random_direction(ecs, position, enemy) {
                 let point = point_in_direction(&position, direction).unwrap();
-                move_character(ecs, *enemy, point);
+                move_character_action(ecs, *enemy, point);
             }
         }
         BehaviorKind::Explode => {

--- a/src/clash/character.rs
+++ b/src/clash/character.rs
@@ -1,24 +1,14 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Clone)]
-pub struct Health {
-    pub current: u32,
-    pub max: u32,
-}
-
-impl Health {
-    pub fn init(current: u32, max: u32) -> Health {
-        Health { current, max }
-    }
-}
+use super::{Defenses, Strength};
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Character {
-    pub health: Health,
+    pub defenses: Defenses,
 }
 
 impl Character {
-    pub fn init() -> Character {
-        Character { health: Health::init(8, 10) }
+    pub fn init(defenses: Defenses) -> Character {
+        Character { defenses }
     }
 }

--- a/src/clash/character_info.rs
+++ b/src/clash/character_info.rs
@@ -3,12 +3,12 @@ use serde::{Deserialize, Serialize};
 use super::{Defenses, Strength};
 
 #[derive(Serialize, Deserialize, Clone)]
-pub struct Character {
+pub struct CharacterInfo {
     pub defenses: Defenses,
 }
 
-impl Character {
-    pub fn init(defenses: Defenses) -> Character {
-        Character { defenses }
+impl CharacterInfo {
+    pub fn init(defenses: Defenses) -> CharacterInfo {
+        CharacterInfo { defenses }
     }
 }

--- a/src/clash/character_info.rs
+++ b/src/clash/character_info.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use super::{Defenses, Strength};
+use super::Defenses;
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct CharacterInfo {

--- a/src/clash/combat.rs
+++ b/src/clash/combat.rs
@@ -3,7 +3,7 @@ use specs::prelude::*;
 
 use super::*;
 use crate::atlas::{EasyECS, EasyMutECS, EasyMutWorld, Point, SizedPoint};
-use crate::clash::{EventCoordinator, FieldComponent, Logger};
+use crate::clash::{EventCoordinator, FieldComponent};
 
 #[derive(Clone, Copy, Deserialize, Serialize)]
 pub enum FieldKind {

--- a/src/clash/combat.rs
+++ b/src/clash/combat.rs
@@ -225,10 +225,12 @@ pub fn reap_killed(ecs: &mut World) {
 
         for (entity, character_info, player) in (&entities, &character_infos, (&players).maybe()).join() {
             if character_info.character.defenses.health == 0 {
+                // We do not remove the player on death, as the UI assumes existance (and may paint before tick)
                 if player.is_some() {
                     player_dead = true;
+                } else {
+                    dead.push(entity);
                 }
-                dead.push(entity);
             }
         }
     }
@@ -325,7 +327,8 @@ mod tests {
         begin_bolt(&mut ecs, &enemy, Point::init(2, 2), Damage::physical(10), BoltKind::Fire);
         wait_for_animations(&mut ecs);
 
-        assert_eq!(1, find_all_entities(&ecs).len());
+        // We do not remove the player on death, as the UI assumes existance (and may paint before tick)
+        assert_eq!(2, find_all_entities(&ecs).len());
         let _ = ecs.fetch::<PlayerDeadComponent>();
     }
 }

--- a/src/clash/combat.rs
+++ b/src/clash/combat.rs
@@ -69,14 +69,14 @@ impl AttackComponent {
 
 pub fn begin_bolt(ecs: &mut World, source: &Entity, target_position: Point, strength: u32, kind: BoltKind) {
     ecs.shovel(*source, AttackComponent::init(target_position, strength, AttackKind::Ranged(kind)));
-    ecs.raise_event(EventKind::Bolt(BoltState::BeginCast), Some(*source));
+    ecs.raise_event(EventKind::Bolt(BoltState::BeginCastAnimation), Some(*source));
 }
 
 pub fn bolt_event(ecs: &mut World, kind: EventKind, target: Option<Entity>) {
     match kind {
         EventKind::Bolt(state) => match state {
-            BoltState::CompleteCast => start_bolt(ecs, target.unwrap()),
-            BoltState::CompleteFlying => apply_bolt(ecs, target.unwrap()),
+            BoltState::CompleteCastAnimation => start_bolt(ecs, target.unwrap()),
+            BoltState::CompleteFlyingAnimation => apply_bolt(ecs, target.unwrap()),
             _ => {}
         },
         _ => {}
@@ -94,7 +94,7 @@ pub fn start_bolt(ecs: &mut World, source: Entity) {
         .build();
 
     ecs.write_storage::<AttackComponent>().remove(source);
-    ecs.raise_event(EventKind::Bolt(BoltState::BeginFlying), Some(bolt));
+    ecs.raise_event(EventKind::Bolt(BoltState::BeginFlyingAnimation), Some(bolt));
 }
 
 pub fn apply_bolt(ecs: &mut World, bolt: Entity) {
@@ -108,11 +108,11 @@ pub fn apply_bolt(ecs: &mut World, bolt: Entity) {
 
 pub fn begin_melee(ecs: &mut World, source: &Entity, target: Point, strength: u32, kind: WeaponKind) {
     ecs.shovel(*source, AttackComponent::init(target, strength, AttackKind::Melee(kind)));
-    ecs.raise_event(EventKind::Melee(MeleeState::Begin), Some(*source));
+    ecs.raise_event(EventKind::Melee(MeleeState::BeginAnimation), Some(*source));
 }
 
 pub fn melee_event(ecs: &mut World, kind: EventKind, target: Option<Entity>) {
-    if matches!(kind, EventKind::Melee(state) if state.is_complete()) {
+    if matches!(kind, EventKind::Melee(state) if state.is_complete_animation()) {
         apply_melee(ecs, target.unwrap());
     }
 }
@@ -129,14 +129,14 @@ pub fn apply_melee(ecs: &mut World, character: Entity) {
 
 pub fn begin_field(ecs: &mut World, source: &Entity, target: Point, strength: u32, kind: FieldKind) {
     ecs.shovel(*source, AttackComponent::init(target, strength, AttackKind::Field(kind)));
-    ecs.raise_event(EventKind::Field(FieldState::BeginCast), Some(*source));
+    ecs.raise_event(EventKind::Field(FieldState::BeginCastAnimation), Some(*source));
 }
 
 pub fn field_event(ecs: &mut World, kind: EventKind, target: Option<Entity>) {
     match kind {
         EventKind::Field(state) => match state {
-            FieldState::CompleteCast => start_field(ecs, target.unwrap()),
-            FieldState::CompleteFlying => apply_field(ecs, target.unwrap()),
+            FieldState::CompleteCastAnimation => start_field(ecs, target.unwrap()),
+            FieldState::CompleteFlyingAnimation => apply_field(ecs, target.unwrap()),
             _ => {}
         },
         _ => {}
@@ -154,7 +154,7 @@ pub fn start_field(ecs: &mut World, source: Entity) {
         .build();
 
     ecs.write_storage::<AttackComponent>().remove(source);
-    ecs.raise_event(EventKind::Field(FieldState::BeginFlying), Some(field_projectile));
+    ecs.raise_event(EventKind::Field(FieldState::BeginFlyingAnimation), Some(field_projectile));
 }
 
 pub fn apply_field(ecs: &mut World, projectile: Entity) {
@@ -177,11 +177,11 @@ pub fn apply_field(ecs: &mut World, projectile: Entity) {
 }
 
 pub fn begin_explode(ecs: &mut World, source: &Entity) {
-    ecs.raise_event(EventKind::Explode(ExplodeState::Begin), Some(*source));
+    ecs.raise_event(EventKind::Explode(ExplodeState::BeginAnimation), Some(*source));
 }
 
 pub fn explode_event(ecs: &mut World, kind: EventKind, target: Option<Entity>) {
-    if matches!(kind, EventKind::Explode(state) if state.is_complete()) {
+    if matches!(kind, EventKind::Explode(state) if state.is_complete_animation()) {
         apply_explode(ecs, target.unwrap());
     }
 }

--- a/src/clash/components.rs
+++ b/src/clash/components.rs
@@ -164,6 +164,15 @@ impl RandomComponent {
     }
 }
 
+#[derive(Component, Serialize, Deserialize, Clone)]
+pub struct PlayerDeadComponent {}
+
+impl PlayerDeadComponent {
+    pub fn init() -> PlayerDeadComponent {
+        PlayerDeadComponent {}
+    }
+}
+
 pub fn create_world() -> World {
     let mut ecs = World::new();
     ecs.register::<PositionComponent>();
@@ -180,6 +189,7 @@ pub fn create_world() -> World {
     ecs.register::<SkillResourceComponent>();
     ecs.register::<BehaviorComponent>();
     ecs.register::<RandomComponent>();
+    ecs.register::<PlayerDeadComponent>();
     ecs.register::<SimpleMarker<ToSerialize>>();
     // If you add additional components remember to update saveload.rs
 

--- a/src/clash/components.rs
+++ b/src/clash/components.rs
@@ -11,7 +11,7 @@ use specs_derive::*;
 use super::EventCoordinator;
 use super::Log;
 use crate::atlas::{EasyECS, Point, SizedPoint, ToSerialize};
-use crate::clash::{AmmoKind, AttackInfo, BehaviorKind, CharacterInfo, Map};
+use crate::clash::{AmmoKind, AttackInfo, BehaviorKind, CharacterInfo, Defenses, Map};
 
 #[derive(Hash, PartialEq, Eq, Component, ConvertSaveload, Clone)]
 pub struct TimeComponent {
@@ -207,13 +207,17 @@ pub fn create_world() -> World {
     ecs
 }
 
-pub trait Positions {
+pub trait ShortInfo {
     fn get_position(&self, entity: &Entity) -> SizedPoint;
+    fn get_defenses(&self, entity: &Entity) -> Defenses;
 }
 
-impl Positions for World {
+impl ShortInfo for World {
     fn get_position(&self, entity: &Entity) -> SizedPoint {
         self.read_storage::<PositionComponent>().grab(*entity).position
+    }
+    fn get_defenses(&self, entity: &Entity) -> Defenses {
+        self.read_storage::<CharacterInfoComponent>().grab(*entity).character.defenses.clone()
     }
 }
 

--- a/src/clash/components.rs
+++ b/src/clash/components.rs
@@ -11,7 +11,7 @@ use specs_derive::*;
 use super::EventCoordinator;
 use super::Log;
 use crate::atlas::{EasyECS, Point, SizedPoint, ToSerialize};
-use crate::clash::{AmmoKind, AttackInfo, BehaviorKind, Character, Map};
+use crate::clash::{AmmoKind, AttackInfo, BehaviorKind, CharacterInfo, Map};
 
 #[derive(Hash, PartialEq, Eq, Component, ConvertSaveload, Clone)]
 pub struct TimeComponent {
@@ -50,11 +50,11 @@ impl PlayerComponent {
 
 #[derive(Component, ConvertSaveload, Clone)]
 pub struct CharacterInfoComponent {
-    pub character: Character,
+    pub character: CharacterInfo,
 }
 
 impl CharacterInfoComponent {
-    pub const fn init(character: Character) -> CharacterInfoComponent {
+    pub const fn init(character: CharacterInfo) -> CharacterInfoComponent {
         CharacterInfoComponent { character }
     }
 }

--- a/src/clash/components.rs
+++ b/src/clash/components.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use rand::prelude::*;
 use serde::{Deserialize, Serialize};
 use specs::error::NoError;
 use specs::prelude::*;
@@ -152,6 +153,17 @@ impl BehaviorComponent {
     }
 }
 
+#[derive(Component, Clone)] // NotConvertSaveload
+pub struct RandomComponent {
+    pub rand: StdRng,
+}
+
+impl RandomComponent {
+    pub fn init() -> RandomComponent {
+        RandomComponent { rand: StdRng::from_entropy() }
+    }
+}
+
 pub fn create_world() -> World {
     let mut ecs = World::new();
     ecs.register::<PositionComponent>();
@@ -167,6 +179,7 @@ pub fn create_world() -> World {
     ecs.register::<MovementComponent>();
     ecs.register::<SkillResourceComponent>();
     ecs.register::<BehaviorComponent>();
+    ecs.register::<RandomComponent>();
     ecs.register::<SimpleMarker<ToSerialize>>();
     // If you add additional components remember to update saveload.rs
 
@@ -174,6 +187,7 @@ pub fn create_world() -> World {
     ecs.register::<super::EventComponent>();
     ecs.insert(super::EventComponent::init());
 
+    ecs.insert(RandomComponent::init());
     ecs.insert(FrameComponent::init());
     ecs.insert(LogComponent::init());
     ecs.insert(SimpleMarkerAllocator::<ToSerialize>::new());

--- a/src/clash/components.rs
+++ b/src/clash/components.rs
@@ -197,6 +197,7 @@ pub fn create_world() -> World {
     ecs.subscribe(super::combat::melee_event);
     ecs.subscribe(super::combat::field_event);
     ecs.subscribe(super::combat::explode_event);
+    ecs.subscribe(super::defenses::defense_event);
 
     #[cfg(test)]
     {

--- a/src/clash/defenses.rs
+++ b/src/clash/defenses.rs
@@ -4,26 +4,7 @@ use rand::prelude::*;
 use serde::{Deserialize, Serialize};
 use specs::prelude::*;
 
-use super::{CharacterInfoComponent, EventKind, MoveState, Strength};
-
-pub enum DamageKind {
-    Physical,
-}
-
-pub struct Damage {
-    pub amount: Strength,
-    pub kind: DamageKind,
-}
-
-impl Damage {
-    pub fn init(amount: Strength, kind: DamageKind) -> Damage {
-        Damage { amount, kind }
-    }
-
-    pub fn dice(&self) -> u32 {
-        self.amount.dice
-    }
-}
+use super::{CharacterInfoComponent, Damage, EventKind, MoveState, Strength};
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Defenses {
@@ -100,8 +81,7 @@ fn apply_with_remain(to_apply: u32, pool: u32) -> (u32, u32) {
 mod tests {
     use super::super::*;
     use super::*;
-    use crate::atlas::{EasyECS, EasyMutECS, EasyMutWorld, SizedPoint};
-    use assert_approx_eq::assert_approx_eq;
+    use crate::atlas::{EasyECS, EasyMutECS, SizedPoint};
 
     #[test]
     fn apply_remain() {

--- a/src/clash/defenses.rs
+++ b/src/clash/defenses.rs
@@ -1,0 +1,94 @@
+use super::Strength;
+use rand::prelude::*;
+
+enum DamageKind {
+    Physical,
+}
+
+struct Damage {
+    amount: Strength,
+    kind: DamageKind,
+}
+
+impl Damage {
+    pub fn init(amount: Strength, kind: DamageKind) -> Damage {
+        Damage { amount, kind }
+    }
+}
+
+struct Defenses {
+    dodge: Strength,
+    armor: Strength,
+    absorb: u32,
+    health: u32,
+}
+
+impl Defenses {
+    pub fn init(dodge: u32, armor: u32, absorb: u32, health: u32) -> Defenses {
+        Defenses {
+            dodge: Strength::init(dodge),
+            armor: Strength::init(armor),
+            absorb,
+            health,
+        }
+    }
+
+    pub fn apply_damage<R: Rng + ?Sized>(&mut self, damage: Damage, rng: &mut R) {
+        let damage = damage.amount.roll(rng);
+
+        let (health_damage, _) = apply_with_remain(damage, self.health);
+        self.health -= health_damage;
+    }
+}
+
+fn apply_with_remain(to_apply: u32, pool: u32) -> (u32, u32) {
+    if to_apply <= pool {
+        (to_apply, 0)
+    } else {
+        (pool, to_apply - pool)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn apply_remain() {
+        assert_eq!((2, 0), apply_with_remain(2, 5));
+        assert_eq!((5, 0), apply_with_remain(5, 5));
+        assert_eq!((5, 5), apply_with_remain(10, 5));
+    }
+
+    #[test]
+    fn no_defense_full_damage() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let mut def = Defenses::init(0, 0, 0, 10);
+        def.apply_damage(Damage::init(Strength::init(4), DamageKind::Physical), &mut rng);
+        assert!(def.health > 0);
+        assert!(def.health < 5);
+    }
+
+    #[test]
+    fn no_defense_overkill_leaves_at_zero() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let mut def = Defenses::init(0, 0, 0, 10);
+        def.apply_damage(Damage::init(Strength::init(10), DamageKind::Physical), &mut rng);
+        assert_eq!(0, def.health);
+    }
+
+    #[test]
+    fn dodge_reduces_damage_up_to_strength() {}
+
+    #[test]
+    fn extra_dodge_saved_after_roll() {}
+
+    #[test]
+    fn regain_dodge() {}
+
+    #[test]
+    fn armor_reduces_every_hit() {}
+
+    #[test]
+    fn absorb_takes_all_damage_before_life() {}
+}

--- a/src/clash/defenses.rs
+++ b/src/clash/defenses.rs
@@ -1,14 +1,15 @@
 use std::cmp;
 
 use rand::prelude::*;
+use serde::{Deserialize, Serialize};
 
 use super::Strength;
 
-enum DamageKind {
+pub enum DamageKind {
     Physical,
 }
 
-struct Damage {
+pub struct Damage {
     pub amount: Strength,
     pub kind: DamageKind,
 }
@@ -23,7 +24,8 @@ impl Damage {
     }
 }
 
-struct Defenses {
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Defenses {
     dodge: u32,
     armor: u32,
     absorb: u32,

--- a/src/clash/events.rs
+++ b/src/clash/events.rs
@@ -5,7 +5,7 @@ use specs_derive::Component;
 pub enum MoveState {
     BeginAnimation,
     CompleteAnimation,
-    Complete (u32)
+    Complete(u32),
 }
 
 #[derive(Copy, Clone, is_enum_variant)]

--- a/src/clash/events.rs
+++ b/src/clash/events.rs
@@ -3,36 +3,36 @@ use specs_derive::Component;
 
 #[derive(Copy, Clone, is_enum_variant)]
 pub enum MoveState {
-    Begin,
-    Complete,
+    BeginAnimation,
+    CompleteAnimation,
 }
 
 #[derive(Copy, Clone, is_enum_variant)]
 pub enum BoltState {
-    BeginCast,
-    CompleteCast,
-    BeginFlying,
-    CompleteFlying,
+    BeginCastAnimation,
+    CompleteCastAnimation,
+    BeginFlyingAnimation,
+    CompleteFlyingAnimation,
 }
 
 #[derive(Copy, Clone, is_enum_variant)]
 pub enum MeleeState {
-    Begin,
-    Complete,
+    BeginAnimation,
+    CompleteAnimation,
 }
 
 #[derive(Copy, Clone, is_enum_variant)]
 pub enum FieldState {
-    BeginCast,
-    CompleteCast,
-    BeginFlying,
-    CompleteFlying,
+    BeginCastAnimation,
+    CompleteCastAnimation,
+    BeginFlyingAnimation,
+    CompleteFlyingAnimation,
 }
 
 #[derive(Copy, Clone, is_enum_variant)]
 pub enum ExplodeState {
-    Begin,
-    Complete,
+    BeginAnimation,
+    CompleteAnimation,
 }
 
 #[derive(Copy, Clone)]

--- a/src/clash/events.rs
+++ b/src/clash/events.rs
@@ -5,6 +5,7 @@ use specs_derive::Component;
 pub enum MoveState {
     BeginAnimation,
     CompleteAnimation,
+    Complete (u32)
 }
 
 #[derive(Copy, Clone, is_enum_variant)]

--- a/src/clash/physics.rs
+++ b/src/clash/physics.rs
@@ -16,16 +16,22 @@ pub fn move_event(ecs: &mut World, kind: EventKind, target: Option<Entity>) {
 }
 
 pub fn complete_move(ecs: &mut World, entity: Entity) {
+    let current_position = ecs.get_position(&entity);
     let new_position = {
         let mut movements = ecs.write_storage::<MovementComponent>();
         let new_position = movements.grab(entity).new_position;
         movements.remove(entity);
         new_position.origin
     };
+    let distance = current_position.distance_to(new_position).unwrap();
 
-    let mut positions = ecs.write_storage::<PositionComponent>();
-    let position = &mut positions.grab_mut(entity);
-    position.move_to(new_position);
+    {
+        let mut positions = ecs.write_storage::<PositionComponent>();
+        let position = &mut positions.grab_mut(entity);
+        position.move_to(new_position);
+    }
+
+    ecs.raise_event(EventKind::Move(MoveState::Complete(distance)), Some(entity));
 }
 
 pub fn point_in_direction(initial: &SizedPoint, direction: Direction) -> Option<SizedPoint> {

--- a/src/clash/physics.rs
+++ b/src/clash/physics.rs
@@ -3,13 +3,14 @@ use specs::prelude::*;
 use super::*;
 use crate::atlas::{EasyECS, EasyMutECS, EasyMutWorld, Point, SizedPoint};
 
+// Begin the move itself, does not spend time
 pub fn begin_move(ecs: &mut World, entity: &Entity, new_position: SizedPoint) {
     ecs.shovel(*entity, MovementComponent::init(new_position));
-    ecs.raise_event(EventKind::Move(MoveState::Begin), Some(*entity));
+    ecs.raise_event(EventKind::Move(MoveState::BeginAnimation), Some(*entity));
 }
 
 pub fn move_event(ecs: &mut World, kind: EventKind, target: Option<Entity>) {
-    if matches!(kind, EventKind::Move(state) if state.is_complete()) {
+    if matches!(kind, EventKind::Move(state) if state.is_complete_animation()) {
         complete_move(ecs, target.unwrap());
     }
 }
@@ -92,6 +93,7 @@ pub fn can_move_character(ecs: &World, mover: &Entity, new: SizedPoint) -> bool 
     is_area_clear(ecs, &new.all_positions(), mover) && has_exhaustion
 }
 
+// Move a character, spending standard time and exhaustion
 pub fn move_character_action(ecs: &mut World, entity: Entity, new: SizedPoint) -> bool {
     if !can_move_character(ecs, &entity, new) {
         return false;

--- a/src/clash/physics.rs
+++ b/src/clash/physics.rs
@@ -92,7 +92,7 @@ pub fn can_move_character(ecs: &World, mover: &Entity, new: SizedPoint) -> bool 
     is_area_clear(ecs, &new.all_positions(), mover) && has_exhaustion
 }
 
-pub fn move_character(ecs: &mut World, entity: Entity, new: SizedPoint) -> bool {
+pub fn move_character_action(ecs: &mut World, entity: Entity, new: SizedPoint) -> bool {
     if !can_move_character(ecs, &entity, new) {
         return false;
     }
@@ -152,7 +152,7 @@ mod tests {
         let entity = find_at(&ecs, 2, 2);
         assert_position(&ecs, &entity, Point::init(2, 2));
 
-        let success = move_character(&mut ecs, entity, SizedPoint::init(2, 3));
+        let success = move_character_action(&mut ecs, entity, SizedPoint::init(2, 3));
         assert_eq!(true, success);
         wait_for_animations(&mut ecs);
 
@@ -171,7 +171,7 @@ mod tests {
 
         assert_position(&ecs, &entity, Point::init(2, 2));
 
-        let success = move_character(&mut ecs, entity, SizedPoint::init(2, 3));
+        let success = move_character_action(&mut ecs, entity, SizedPoint::init(2, 3));
         assert_eq!(true, success);
         wait_for_animations(&mut ecs);
 
@@ -188,7 +188,7 @@ mod tests {
 
         assert_position(&ecs, &entity, Point::init(2, 2));
 
-        let success = move_character(&mut ecs, entity, SizedPoint::init(2, 3));
+        let success = move_character_action(&mut ecs, entity, SizedPoint::init(2, 3));
         assert_eq!(false, success);
         wait_for_animations(&mut ecs);
 
@@ -202,7 +202,7 @@ mod tests {
 
         assert_position(&ecs, &entity, Point::init(2, 2));
 
-        let success = move_character(&mut ecs, entity, SizedPoint::init(2, 3));
+        let success = move_character_action(&mut ecs, entity, SizedPoint::init(2, 3));
         assert_eq!(false, success);
         wait_for_animations(&mut ecs);
 
@@ -215,7 +215,7 @@ mod tests {
         let entity = find_at(&ecs, 13, 13);
         assert_position(&ecs, &entity, Point::init(13, 13));
 
-        let success = move_character(&mut ecs, entity, SizedPoint::init(13, 14));
+        let success = move_character_action(&mut ecs, entity, SizedPoint::init(13, 14));
         assert_eq!(false, success);
         wait_for_animations(&mut ecs);
 
@@ -231,7 +231,7 @@ mod tests {
             .build();
         let bottom = find_at(&ecs, 2, 4);
 
-        assert_eq!(false, move_character(&mut ecs, bottom, SizedPoint::init_multi(2, 3, 2, 2)));
+        assert_eq!(false, move_character_action(&mut ecs, bottom, SizedPoint::init_multi(2, 3, 2, 2)));
         wait_for_animations(&mut ecs);
     }
 
@@ -242,7 +242,7 @@ mod tests {
         // All of these tests by default do not include an SkillResourceComponent, so they get no exhaustion
         ecs.shovel(player, SkillResourceComponent::init(&[]));
 
-        assert_eq!(true, move_character(&mut ecs, player, SizedPoint::init(2, 3)));
+        assert_eq!(true, move_character_action(&mut ecs, player, SizedPoint::init(2, 3)));
         wait_for_animations(&mut ecs);
 
         let skills = ecs.read_storage::<SkillResourceComponent>();
@@ -260,7 +260,7 @@ mod tests {
         };
         ecs.shovel(player, skill_resource);
 
-        assert_eq!(false, move_character(&mut ecs, player, SizedPoint::init(2, 3)));
+        assert_eq!(false, move_character_action(&mut ecs, player, SizedPoint::init(2, 3)));
         let skills = ecs.read_storage::<SkillResourceComponent>();
         assert_approx_eq!(100.0, skills.grab(player).exhaustion);
     }

--- a/src/clash/skills.rs
+++ b/src/clash/skills.rs
@@ -386,10 +386,7 @@ fn reload(ecs: &mut World, invoker: &Entity, kind: AmmoKind) {
 
 #[cfg(test)]
 mod tests {
-    use super::super::{
-        add_ticks, create_test_state, find_at, find_first_entity, get_ticks, wait_for_animations, Character, CharacterInfoComponent, LogComponent,
-        PositionComponent,
-    };
+    use super::super::{add_ticks, create_test_state, find_at, find_first_entity, get_ticks, wait_for_animations, LogComponent};
     use super::*;
     use crate::atlas::{EasyMutWorld, SizedPoint};
 
@@ -461,10 +458,7 @@ mod tests {
 
         let info = SkillInfo::init_with_distance("", TargetType::Tile, SkillEffect::None, Some(2), true);
         assert_eq!(true, is_good_target(&mut ecs, &entity, &info, Point::init(2, 4)));
-        ecs.create_entity()
-            .with(PositionComponent::init(SizedPoint::init(2, 3)))
-            .with(CharacterInfoComponent::init(Character::init()))
-            .build();
+        make_test_character(&mut ecs, SizedPoint::init(2, 3), 0);
 
         assert_eq!(false, is_good_target(&mut ecs, &entity, &info, Point::init(2, 4)));
     }

--- a/src/clash/skills.rs
+++ b/src/clash/skills.rs
@@ -407,7 +407,7 @@ fn reload(ecs: &mut World, invoker: &Entity, kind: AmmoKind) {
 
 #[cfg(test)]
 mod tests {
-    use super::super::{add_ticks, create_test_state, find_at, find_first_entity, get_ticks, wait_for_animations, LogComponent};
+    use super::super::{add_ticks, create_test_state, find_at, find_first_entity, get_ticks, wait_for_animations};
     use super::*;
     use crate::atlas::{EasyMutWorld, SizedPoint};
 

--- a/src/clash/skills.rs
+++ b/src/clash/skills.rs
@@ -22,10 +22,10 @@ pub enum TargetType {
 pub enum SkillEffect {
     None,
     Move,
-    RangedAttack(u32, BoltKind),
-    MeleeAttack(u32, WeaponKind),
+    RangedAttack(Damage, BoltKind),
+    MeleeAttack(Damage, WeaponKind),
     Reload(AmmoKind),
-    FieldEffect(u32, FieldKind),
+    FieldEffect(Damage, FieldKind),
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, IntoEnumIterator, Debug, Deserialize, Serialize)]
@@ -199,11 +199,11 @@ lazy_static! {
             );
             m.insert(
                 "TestRanged",
-                SkillInfo::init_with_distance("", TargetType::Enemy, SkillEffect::RangedAttack(2, BoltKind::Fire), Some(2), false),
+                SkillInfo::init_with_distance("", TargetType::Enemy, SkillEffect::RangedAttack(Damage::physical(2), BoltKind::Fire), Some(2), false),
             );
             m.insert(
                 "TestMelee",
-                SkillInfo::init_with_distance("", TargetType::Enemy, SkillEffect::MeleeAttack(2, WeaponKind::Sword), Some(1), false),
+                SkillInfo::init_with_distance("", TargetType::Enemy, SkillEffect::MeleeAttack(Damage::physical(2), WeaponKind::Sword), Some(1), false),
             );
             m.insert(
                 "TestAmmo",
@@ -218,7 +218,10 @@ lazy_static! {
                     .with_ammo(AmmoKind::Bullets, 1)
                     .with_exhaustion(25.0),
             );
-            m.insert("TestField", SkillInfo::init("", TargetType::Any, SkillEffect::FieldEffect(1, FieldKind::Fire)));
+            m.insert(
+                "TestField",
+                SkillInfo::init("", TargetType::Any, SkillEffect::FieldEffect(Damage::physical(1), FieldKind::Fire)),
+            );
         }
         m.insert(
             "Dash",
@@ -233,7 +236,7 @@ lazy_static! {
             SkillInfo::init_with_distance(
                 "SpellBook01_37.png",
                 TargetType::Enemy,
-                SkillEffect::RangedAttack(10, BoltKind::Bullet),
+                SkillEffect::RangedAttack(Damage::physical(10), BoltKind::Bullet),
                 Some(10),
                 true,
             )
@@ -245,7 +248,7 @@ lazy_static! {
             SkillInfo::init_with_distance(
                 "SpellBook06_117.png",
                 TargetType::Enemy,
-                SkillEffect::RangedAttack(5, BoltKind::Fire),
+                SkillEffect::RangedAttack(Damage::physical(5), BoltKind::Fire),
                 Some(15),
                 true,
             )
@@ -256,14 +259,20 @@ lazy_static! {
             SkillInfo::init_with_distance(
                 "SpellBook01_76.png",
                 TargetType::Enemy,
-                SkillEffect::MeleeAttack(5, WeaponKind::Sword),
+                SkillEffect::MeleeAttack(Damage::physical(5), WeaponKind::Sword),
                 Some(1),
                 true,
             ),
         );
         m.insert(
             "Delayed Blast",
-            SkillInfo::init_with_distance("en_craft_96.png", TargetType::Any, SkillEffect::FieldEffect(1, FieldKind::Fire), Some(3), false),
+            SkillInfo::init_with_distance(
+                "en_craft_96.png",
+                TargetType::Any,
+                SkillEffect::FieldEffect(Damage::physical(5), FieldKind::Fire),
+                Some(3),
+                false,
+            ),
         );
 
         m
@@ -345,10 +354,10 @@ pub fn invoke_skill(ecs: &mut World, invoker: &Entity, name: &str, target: Optio
             let position = ecs.get_position(invoker).move_to(target.unwrap());
             begin_move(ecs, invoker, position);
         }
-        SkillEffect::RangedAttack(strength, kind) => begin_bolt(ecs, &invoker, target.unwrap(), *strength, *kind),
-        SkillEffect::MeleeAttack(strength, kind) => begin_melee(ecs, &invoker, target.unwrap(), *strength, *kind),
+        SkillEffect::RangedAttack(damage, kind) => begin_bolt(ecs, &invoker, target.unwrap(), *damage, *kind),
+        SkillEffect::MeleeAttack(damage, kind) => begin_melee(ecs, &invoker, target.unwrap(), *damage, *kind),
         SkillEffect::Reload(kind) => reload(ecs, &invoker, *kind),
-        SkillEffect::FieldEffect(strength, kind) => begin_field(ecs, &invoker, target.unwrap(), *strength, *kind),
+        SkillEffect::FieldEffect(damage, kind) => begin_field(ecs, &invoker, target.unwrap(), *damage, *kind),
         SkillEffect::None => ecs.log(&format!("Invoking {}", name)),
     }
 

--- a/src/clash/skills.rs
+++ b/src/clash/skills.rs
@@ -710,4 +710,17 @@ mod tests {
         wait_for_animations(&mut ecs);
         assert_eq!(1, ecs.read_resource::<LogComponent>().log.count());
     }
+
+    #[test]
+    fn dodge_restored_by_skill_movement() {
+        let mut ecs = create_test_state().with_character(2, 2, 100).with_map().build();
+        let entity = find_at(&ecs, 2, 2);
+        ecs.write_storage::<CharacterInfoComponent>().grab_mut(entity).character.defenses = Defenses::init(0, 5, 0, 0, 10);
+
+        invoke_skill(&mut ecs, &entity, "TestMove", Some(Point::init(3, 3)));
+        wait_for_animations(&mut ecs);
+
+        let dodge = ecs.read_storage::<CharacterInfoComponent>().grab(entity).character.defenses.dodge;
+        assert_eq!(4, dodge);
+    }
 }

--- a/src/clash/strength.rs
+++ b/src/clash/strength.rs
@@ -11,7 +11,7 @@ impl Strength {
         Strength { dice }
     }
 
-    pub fn roll<R: Rng + ?Sized>(self, rng: &mut R) -> u32 {
+    pub fn roll<R: Rng + ?Sized>(&self, rng: &mut R) -> u32 {
         let fixed_count = self.dice / 2;
         let open_count = self.dice - fixed_count;
         let fixed_value = fixed_count * STRENGTH_DICE_SIDES;

--- a/src/clash/strength.rs
+++ b/src/clash/strength.rs
@@ -1,7 +1,9 @@
 use rand::prelude::*;
+use serde::{Deserialize, Serialize};
 
 pub const STRENGTH_DICE_SIDES: u32 = 2;
 
+#[derive(Clone, Copy, Deserialize, Serialize)]
 pub struct Strength {
     pub dice: u32,
 }
@@ -17,6 +19,34 @@ impl Strength {
         let fixed_value = fixed_count * STRENGTH_DICE_SIDES;
         let open_value = rng.gen_range(open_count, (open_count * STRENGTH_DICE_SIDES) + 1);
         fixed_value + open_value
+    }
+}
+
+#[derive(Clone, Copy, Deserialize, Serialize)]
+pub enum DamageKind {
+    Physical,
+}
+
+#[derive(Clone, Copy, Deserialize, Serialize)]
+pub struct Damage {
+    pub amount: Strength,
+    pub kind: DamageKind,
+}
+
+impl Damage {
+    pub fn init(amount: Strength, kind: DamageKind) -> Damage {
+        Damage { amount, kind }
+    }
+
+    pub fn physical(amount: u32) -> Damage {
+        Damage {
+            amount: Strength::init(amount),
+            kind: DamageKind::Physical,
+        }
+    }
+
+    pub fn dice(&self) -> u32 {
+        self.amount.dice
     }
 }
 

--- a/src/clash/strength.rs
+++ b/src/clash/strength.rs
@@ -1,0 +1,35 @@
+use rand::prelude::*;
+
+pub const STRENGTH_DICE_SIDES: u32 = 2;
+
+pub struct Strength {
+    pub dice: u32,
+}
+
+impl Strength {
+    pub fn init(dice: u32) -> Strength {
+        Strength { dice }
+    }
+
+    pub fn roll<R: Rng + ?Sized>(self, rng: &mut R) -> u32 {
+        let fixed_count = self.dice / 2;
+        let open_count = self.dice - fixed_count;
+        let fixed_value = fixed_count * STRENGTH_DICE_SIDES;
+        let open_value = rng.gen_range(open_count, (open_count * STRENGTH_DICE_SIDES) + 1);
+        fixed_value + open_value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base_value() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let d = Strength::init(14);
+        let v = d.roll(&mut rng);
+        // 7 * 2 + 7 * (1,2) = 21 - 28
+        assert_eq!(true, v >= 21 && v <= 28);
+    }
+}

--- a/src/clash/strength.rs
+++ b/src/clash/strength.rs
@@ -39,10 +39,7 @@ impl Damage {
     }
 
     pub fn physical(amount: u32) -> Damage {
-        Damage {
-            amount: Strength::init(amount),
-            kind: DamageKind::Physical,
-        }
+        Damage::init(Strength::init(amount), DamageKind::Physical)
     }
 
     pub fn dice(&self) -> u32 {

--- a/src/clash/test_helpers.rs
+++ b/src/clash/test_helpers.rs
@@ -80,7 +80,7 @@ pub fn make_test_character(ecs: &mut World, position: SizedPoint, time: i32) {
     ecs.create_entity()
         .with(TimeComponent::init(time))
         .with(PositionComponent::init(position))
-        .with(CharacterInfoComponent::init(Character::init(Defenses::init(0, 0, 0, 0, 1))))
+        .with(CharacterInfoComponent::init(CharacterInfo::init(Defenses::init(0, 0, 0, 0, 1))))
         .with(SkillResourceComponent::init(&[]))
         .build();
 }

--- a/src/clash/test_helpers.rs
+++ b/src/clash/test_helpers.rs
@@ -80,7 +80,7 @@ pub fn make_test_character(ecs: &mut World, position: SizedPoint, time: i32) {
     ecs.create_entity()
         .with(TimeComponent::init(time))
         .with(PositionComponent::init(position))
-        .with(CharacterInfoComponent::init(CharacterInfo::init(Defenses::init(0, 0, 0, 0, 1))))
+        .with(CharacterInfoComponent::init(CharacterInfo::init(Defenses::init(0, 0, 0, 0, 10))))
         .with(SkillResourceComponent::init(&[]))
         .build();
 }

--- a/src/clash/test_helpers.rs
+++ b/src/clash/test_helpers.rs
@@ -80,7 +80,7 @@ pub fn make_test_character(ecs: &mut World, position: SizedPoint, time: i32) {
     ecs.create_entity()
         .with(TimeComponent::init(time))
         .with(PositionComponent::init(position))
-        .with(CharacterInfoComponent::init(Character::init(Defenses::init(0, 0, 0, 1))))
+        .with(CharacterInfoComponent::init(Character::init(Defenses::init(0, 0, 0, 0, 1))))
         .with(SkillResourceComponent::init(&[]))
         .build();
 }

--- a/src/clash/test_helpers.rs
+++ b/src/clash/test_helpers.rs
@@ -1,10 +1,7 @@
 use specs::prelude::*;
 
-use super::{
-    create_world, find_character_at_location, Character, CharacterInfoComponent, Map, MapComponent, PlayerComponent, PositionComponent, SkillResourceComponent,
-    TimeComponent,
-};
-use crate::atlas::{Point, SizedPoint};
+use super::*;
+use crate::atlas::{EasyMutWorld, Point, SizedPoint};
 
 pub struct StateBuilder {
     ecs: World,
@@ -17,36 +14,19 @@ impl StateBuilder {
     }
 
     pub fn with_character<'a>(&'a mut self, x: u32, y: u32, time: i32) -> &'a mut Self {
-        self.ecs
-            .create_entity()
-            .with(TimeComponent::init(time))
-            .with(PositionComponent::init(SizedPoint::init(x, y)))
-            .with(CharacterInfoComponent::init(Character::init()))
-            .with(SkillResourceComponent::init(&[]))
-            .build();
+        make_test_character(&mut self.ecs, SizedPoint::init(x, y), time);
         self
     }
 
     pub fn with_sized_character<'a>(&'a mut self, position: SizedPoint, time: i32) -> &'a mut Self {
-        self.ecs
-            .create_entity()
-            .with(TimeComponent::init(time))
-            .with(PositionComponent::init(position))
-            .with(CharacterInfoComponent::init(Character::init()))
-            .with(SkillResourceComponent::init(&[]))
-            .build();
+        make_test_character(&mut self.ecs, position, time);
         self
     }
 
     pub fn with_player<'a>(&'a mut self, x: u32, y: u32, time: i32) -> &'a mut Self {
-        self.ecs
-            .create_entity()
-            .with(TimeComponent::init(time))
-            .with(PositionComponent::init(SizedPoint::init(x, y)))
-            .with(PlayerComponent::init())
-            .with(CharacterInfoComponent::init(Character::init()))
-            .with(SkillResourceComponent::init(&[]))
-            .build();
+        make_test_character(&mut self.ecs, SizedPoint::init(x, y), time);
+        let player = find_at(&self.ecs, x, y);
+        self.ecs.shovel(player, PlayerComponent::init());
         self
     }
 
@@ -94,4 +74,13 @@ pub fn find_all_entities(ecs: &World) -> Vec<Entity> {
         all.push(entity);
     }
     all
+}
+
+pub fn make_test_character(ecs: &mut World, position: SizedPoint, time: i32) {
+    ecs.create_entity()
+        .with(TimeComponent::init(time))
+        .with(PositionComponent::init(position))
+        .with(CharacterInfoComponent::init(Character::init(Defenses::init(0, 0, 0, 1))))
+        .with(SkillResourceComponent::init(&[]))
+        .build();
 }

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -2,7 +2,10 @@
 // - Director processes event loop and dispatches to the current Scene trait object for input/render
 
 mod director;
-mod scene;
-
 pub use director::{Director, EventStatus};
+
+mod scene;
 pub use scene::Scene;
+
+mod storyteller;
+pub use storyteller::Storyteller;

--- a/src/conductor/director.rs
+++ b/src/conductor/director.rs
@@ -5,7 +5,7 @@ use sdl2::event::Event;
 
 use super::Scene;
 
-use crate::after_image::RenderContext;
+use crate::after_image::RenderContextHolder;
 use crate::atlas::BoxResult;
 
 #[allow(dead_code)]
@@ -27,12 +27,11 @@ impl<'a> Director<'a> {
     pub fn change_scene(&mut self, scene: Box<dyn Scene + 'a>) {
         self.scene = scene;
     }
-
-    pub fn run(&mut self, render_context: &'a mut RenderContext) -> BoxResult<()> {
+    pub fn run(&mut self, render_context: RenderContextHolder) -> BoxResult<()> {
         let mut frame = 0;
         loop {
             let start_frame = Instant::now();
-            for event in render_context.event_pump.poll_iter() {
+            for event in render_context.borrow_mut().event_pump.poll_iter() {
                 let status = match event {
                     Event::Quit { .. } => {
                         self.scene.on_quit()?;
@@ -59,7 +58,7 @@ impl<'a> Director<'a> {
 
             self.scene.tick(frame)?;
 
-            self.scene.render(&mut render_context.canvas, frame)?;
+            self.scene.render(&mut render_context.borrow_mut().canvas, frame)?;
 
             let end_frame = Instant::now();
             if let Some(duration) = end_frame.checked_duration_since(start_frame) {

--- a/src/conductor/director.rs
+++ b/src/conductor/director.rs
@@ -56,7 +56,11 @@ impl<'a> Director<'a> {
                 }
             }
 
-            self.scene.tick(frame)?;
+            match self.scene.tick(frame)? {
+                EventStatus::Quit => return Ok(()),
+                EventStatus::NewScene(s) => self.change_scene(s),
+                EventStatus::Continue => {}
+            }
 
             self.scene.render(&mut render_context.borrow_mut().canvas, frame)?;
 

--- a/src/conductor/director.rs
+++ b/src/conductor/director.rs
@@ -29,6 +29,7 @@ impl<'a> Director<'a> {
     pub fn change_scene(&mut self, scene: Box<dyn Scene + 'a>) {
         self.scene = scene;
     }
+
     pub fn run(&mut self, render_context: RenderContextHolder) -> BoxResult<()> {
         let mut frame = 0;
         loop {
@@ -51,6 +52,13 @@ impl<'a> Director<'a> {
             }
 
             self.scene.tick(frame);
+
+            match self.storyteller.check_place(self.scene.get_state()) {
+                EventStatus::NewScene(scene) => self.change_scene(scene),
+                EventStatus::Quit => return Ok(()),
+                EventStatus::Continue => {}
+            }
+
             self.scene.render(&mut render_context.borrow_mut().canvas, frame)?;
 
             let end_frame = Instant::now();

--- a/src/conductor/director.rs
+++ b/src/conductor/director.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 
 use sdl2::event::Event;
 
-use super::Scene;
+use super::{Scene, Storyteller};
 
 use crate::after_image::RenderContextHolder;
 use crate::atlas::BoxResult;
@@ -17,11 +17,13 @@ pub enum EventStatus {
 
 pub struct Director<'a> {
     scene: Box<dyn Scene + 'a>,
+    storyteller: Box<dyn Storyteller + 'a>,
 }
 
 impl<'a> Director<'a> {
-    pub fn init(scene: Box<dyn Scene + 'a>) -> Director {
-        Director { scene }
+    pub fn init(storyteller: Box<dyn Storyteller + 'a>) -> Director<'a> {
+        let scene = storyteller.initial_scene();
+        Director { scene, storyteller }
     }
 
     pub fn change_scene(&mut self, scene: Box<dyn Scene + 'a>) {
@@ -32,36 +34,23 @@ impl<'a> Director<'a> {
         loop {
             let start_frame = Instant::now();
             for event in render_context.borrow_mut().event_pump.poll_iter() {
-                let status = match event {
+                match event {
                     Event::Quit { .. } => {
                         self.scene.on_quit()?;
-                        EventStatus::Quit
+                        return Ok(());
                     }
                     Event::KeyDown { keycode, repeat: false, .. } => {
                         if let Some(keycode) = keycode {
                             self.scene.handle_key(keycode)
-                        } else {
-                            EventStatus::Continue
                         }
                     }
                     Event::MouseButtonDown { x, y, mouse_btn, .. } => self.scene.handle_mouse(x, y, Some(mouse_btn)),
                     Event::MouseMotion { x, y, .. } => self.scene.handle_mouse(x, y, None),
-                    _ => EventStatus::Continue,
+                    _ => {}
                 };
-
-                match status {
-                    EventStatus::Quit => return Ok(()),
-                    EventStatus::NewScene(s) => self.change_scene(s),
-                    EventStatus::Continue => {}
-                }
             }
 
-            match self.scene.tick(frame)? {
-                EventStatus::Quit => return Ok(()),
-                EventStatus::NewScene(s) => self.change_scene(s),
-                EventStatus::Continue => {}
-            }
-
+            self.scene.tick(frame);
             self.scene.render(&mut render_context.borrow_mut().canvas, frame)?;
 
             let end_frame = Instant::now();

--- a/src/conductor/scene.rs
+++ b/src/conductor/scene.rs
@@ -1,3 +1,5 @@
+use specs::prelude::*;
+
 use sdl2::keyboard::Keycode;
 use sdl2::mouse::MouseButton;
 
@@ -13,4 +15,5 @@ pub trait Scene {
     fn tick(&mut self, _frame: u64);
 
     fn on_quit(&mut self) -> BoxResult<()>;
+    fn get_state(&self) -> &World;
 }

--- a/src/conductor/scene.rs
+++ b/src/conductor/scene.rs
@@ -14,8 +14,8 @@ pub trait Scene {
         Ok(())
     }
 
-    fn tick(&mut self, _frame: u64) -> BoxResult<()> {
-        Ok(())
+    fn tick(&mut self, _frame: u64) -> BoxResult<EventStatus> {
+        Ok(EventStatus::Continue)
     }
 
     fn on_quit(&mut self) -> BoxResult<()>;

--- a/src/conductor/scene.rs
+++ b/src/conductor/scene.rs
@@ -1,22 +1,16 @@
 use sdl2::keyboard::Keycode;
 use sdl2::mouse::MouseButton;
 
-use super::EventStatus;
 use crate::after_image::RenderCanvas;
 use crate::atlas::BoxResult;
 
 pub trait Scene {
-    fn handle_mouse(&mut self, x: i32, y: i32, button: Option<MouseButton>) -> EventStatus;
-    fn handle_key(&mut self, keycode: Keycode) -> EventStatus;
+    fn handle_mouse(&mut self, x: i32, y: i32, button: Option<MouseButton>);
+    fn handle_key(&mut self, keycode: Keycode);
 
-    fn render(&self, canvas: &mut RenderCanvas, _frame: u64) -> BoxResult<()> {
-        canvas.clear();
-        Ok(())
-    }
+    fn render(&self, canvas: &mut RenderCanvas, _frame: u64) -> BoxResult<()>;
 
-    fn tick(&mut self, _frame: u64) -> BoxResult<EventStatus> {
-        Ok(EventStatus::Continue)
-    }
+    fn tick(&mut self, _frame: u64);
 
     fn on_quit(&mut self) -> BoxResult<()>;
 }

--- a/src/conductor/storyteller.rs
+++ b/src/conductor/storyteller.rs
@@ -4,5 +4,5 @@ use super::{EventStatus, Scene};
 
 pub trait Storyteller {
     fn initial_scene(&self) -> Box<dyn Scene>;
-    fn check_place(&self) -> EventStatus;
+    fn check_place(&self, ecs: &World) -> EventStatus;
 }

--- a/src/conductor/storyteller.rs
+++ b/src/conductor/storyteller.rs
@@ -1,0 +1,8 @@
+use specs::prelude::*;
+
+use super::{EventStatus, Scene};
+
+pub trait Storyteller {
+    fn initial_scene(&self) -> Box<dyn Scene>;
+    fn check_place(&self) -> EventStatus;
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ use conductor::Director;
 mod clash;
 
 mod arena;
-use arena::BattleScene;
+use arena::ArenaStoryteller;
 
 pub fn main() -> BoxResult<()> {
     std::env::set_var("RUST_BACKTRACE", "1");
@@ -46,8 +46,8 @@ pub fn main() -> BoxResult<()> {
     let font_context = Box::from(FontContext::initialize()?).leak();
     let text_renderer = Rc::new(TextRenderer::init(&font_context)?);
 
-    let scene = Box::new(BattleScene::init(&render_context, &text_renderer)?);
-    let mut director = Director::init(scene);
+    let storyteller = Box::new(ArenaStoryteller::init(&render_context, &text_renderer));
+    let mut director = Director::init(storyteller);
     director.run(render_context)?;
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::collapsible_if)]
 #![allow(clippy::single_match)]
 
+use std::{cell::RefCell, rc::Rc};
+
 use leak::Leak;
 
 // Disable annoying black terminal
@@ -39,14 +41,14 @@ pub fn main() -> BoxResult<()> {
         }));
     }
 
-    let mut render_context = RenderContext::initialize()?;
+    let render_context = Rc::new(RefCell::new(RenderContext::initialize()?));
     // See text_renderer.rs for details on this hack
     let font_context = Box::from(FontContext::initialize()?).leak();
-    let text_renderer = TextRenderer::init(&font_context)?;
+    let text_renderer = Rc::new(TextRenderer::init(&font_context)?);
 
-    let scene = Box::new(BattleScene::init(&render_context, &text_renderer)?);
+    let scene = Box::new(BattleScene::init(&render_context, text_renderer)?);
     let mut director = Director::init(scene);
-    director.run(&mut render_context)?;
+    director.run(render_context)?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ pub fn main() -> BoxResult<()> {
     let font_context = Box::from(FontContext::initialize()?).leak();
     let text_renderer = Rc::new(TextRenderer::init(&font_context)?);
 
-    let scene = Box::new(BattleScene::init(&render_context, text_renderer)?);
+    let scene = Box::new(BattleScene::init(&render_context, &text_renderer)?);
     let mut director = Director::init(scene);
     director.run(render_context)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::collapsible_if)]
 #![allow(clippy::single_match)]
 
+use leak::Leak;
+
 // Disable annoying black terminal
 //#![windows_subsystem = "windows"]
 
@@ -38,7 +40,8 @@ pub fn main() -> BoxResult<()> {
     }
 
     let mut render_context = RenderContext::initialize()?;
-    let font_context = FontContext::initialize()?;
+    // See text_renderer.rs for details on this hack
+    let font_context = Box::from(FontContext::initialize()?).leak();
     let text_renderer = TextRenderer::init(&font_context)?;
 
     let scene = Box::new(BattleScene::init(&render_context, &text_renderer)?);


### PR DESCRIPTION
- Enemies now have health, dodge, armor, absorb and strength in attacks.
- Enemies can die, and so can the player.
- Right now we just transition to the initial scene if either happens. 
- Large refactor of screen/text/font helpers to reference count based system to remove ownership hell
- Clarify various animation enum states 
- Add "meta" component, the storyteller which knows how where to start and how to transition between scenes. 