### PR TITLE
Adjust the Temperature of things (Just burning for now)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,4 @@
 # Temperature
-- Show temperature in player stats 
 - Frost (needs status effect)
 
 - Show damage in log

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,23 @@
+- Life bar for enemy
+
+# GS Skills
+- Aimed shot [easy]
+- Triple shot [easy]
+- Shoot and move [moderate]
+- Atune ammo [hard]
+    - Status effect system
+- Showdown [hard]
+    - "Drama" resource
+    - Trait system (with limited duration)
+- Bullets [very_hard]
+    - Temperature system
+    - Trait system (heavy, air)
+
+# Bird Phases
+- Ranged Beam [easy]
+- Melee knockback [moderate]
+    - AOE melee
+    - Knockback skills
+- Explosions with many beams [moderate]
+- Spawn armored eggs, spawn enemy on hatch [moderate]
+- Bird Pass [moderate] (if rest done)

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,15 @@
+# Temperature
+- Show temperature in player stats 
+- Frost (needs status effect)
+
+- Show damage in log
+
+## Overlay for each character
 - Life bar for enemy
+- Show icon when temperature high
+- CT?
+- Armor/Dodge?
+- White bracket frame?
 
 # GS Skills
 - Aimed shot [easy]

--- a/src/arena/spawner.rs
+++ b/src/arena/spawner.rs
@@ -17,7 +17,7 @@ pub fn player(ecs: &mut World) {
         )))
         .with(PositionComponent::init(SizedPoint::init(4, 4)))
         .with(CharacterInfoComponent::init(CharacterInfo::init(
-            Defenses::init(0, 0, 0, 0, 10),
+            Defenses::just_health(10),
             Temperature::init(),
         )))
         .with(PlayerComponent::init())
@@ -33,7 +33,7 @@ pub fn bird_monster(ecs: &mut World) {
         .with(RenderComponent::init(RenderInfo::init(SpriteKinds::MonsterBirdBrown)))
         .with(PositionComponent::init(SizedPoint::init_multi(5, 5, 2, 2)))
         .with(CharacterInfoComponent::init(CharacterInfo::init(
-            Defenses::init(0, 0, 0, 0, 25),
+            Defenses::just_health(25),
             Temperature::init(),
         )))
         .with(BehaviorComponent::init(BehaviorKind::Random))

--- a/src/arena/spawner.rs
+++ b/src/arena/spawner.rs
@@ -16,7 +16,10 @@ pub fn player(ecs: &mut World) {
             CharacterAnimationState::Idle,
         )))
         .with(PositionComponent::init(SizedPoint::init(4, 4)))
-        .with(CharacterInfoComponent::init(CharacterInfo::init(Defenses::init(0, 0, 0, 0, 10))))
+        .with(CharacterInfoComponent::init(CharacterInfo::init(
+            Defenses::init(0, 0, 0, 0, 10),
+            Temperature::init(),
+        )))
         .with(PlayerComponent::init())
         .with(TimeComponent::init(0))
         .with(SkillResourceComponent::init(&[(AmmoKind::Bullets, 6)]).with_focus(1.0))
@@ -29,7 +32,10 @@ pub fn bird_monster(ecs: &mut World) {
     ecs.create_entity()
         .with(RenderComponent::init(RenderInfo::init(SpriteKinds::MonsterBirdBrown)))
         .with(PositionComponent::init(SizedPoint::init_multi(5, 5, 2, 2)))
-        .with(CharacterInfoComponent::init(CharacterInfo::init(Defenses::init(0, 0, 0, 0, 25))))
+        .with(CharacterInfoComponent::init(CharacterInfo::init(
+            Defenses::init(0, 0, 0, 0, 25),
+            Temperature::init(),
+        )))
         .with(BehaviorComponent::init(BehaviorKind::Random))
         .with(TimeComponent::init(0))
         .marked::<SimpleMarker<ToSerialize>>()

--- a/src/arena/views/infobar.rs
+++ b/src/arena/views/infobar.rs
@@ -9,7 +9,7 @@ use specs::prelude::*;
 use super::View;
 use crate::after_image::{FontColor, FontSize, RenderCanvas, TextRenderer};
 use crate::atlas::{BoxResult, EasyECS};
-use crate::clash::{find_player, AmmoKind, SkillResourceComponent};
+use crate::clash::{find_player, AmmoKind, CharacterInfoComponent, SkillResourceComponent};
 
 pub struct InfoBarView {
     position: SDLPoint,
@@ -24,25 +24,46 @@ impl InfoBarView {
         self.text
             .render_text("Info Bar", self.position.x, self.position.y, canvas, FontSize::Large, FontColor::Black)?;
 
+        let mut offset = 30;
+        let player = find_player(&ecs);
+        let char_infos = &ecs.read_storage::<CharacterInfoComponent>();
+        let char_info = char_infos.grab(player);
+
+        // Write out Dodge,Current Dodge, Armor, Absorb, and Health (if not zero)
+        let temperature = char_info.character.temperature.current_temperature;
+        if temperature != 0 {
+            self.text.render_text(
+                format!("Temperature: {:.2}", temperature).as_str(),
+                self.position.x + 4,
+                self.position.y + offset,
+                canvas,
+                FontSize::Small,
+                FontColor::Black,
+            )?;
+            offset += 20;
+        }
+
         let resources = &ecs.read_storage::<SkillResourceComponent>();
-        let resource = resources.grab(find_player(&ecs));
+        let resource = resources.grab(player);
         self.text.render_text(
             format!("Exhaustion: {:.2}", resource.exhaustion).as_str(),
             self.position.x + 4,
-            self.position.y + 30,
+            self.position.y + offset,
             canvas,
             FontSize::Small,
             FontColor::Black,
         )?;
+        offset += 20;
 
         self.text.render_text(
             format!("Focus: {:.2}", resource.focus).as_str(),
             self.position.x + 4,
-            self.position.y + 50,
+            self.position.y + offset,
             canvas,
             FontSize::Small,
             FontColor::Black,
         )?;
+        offset += 20;
 
         for kind in AmmoKind::into_enum_iter() {
             match resource.max.get(&kind) {
@@ -50,11 +71,12 @@ impl InfoBarView {
                     self.text.render_text(
                         format!("{:?}: {:.2}/{:.2}", kind, resource.ammo[&kind], value).as_str(),
                         self.position.x + 4,
-                        self.position.y + 70,
+                        self.position.y + offset,
                         canvas,
                         FontSize::Small,
                         FontColor::Black,
                     )?;
+                    offset += 20;
                 }
                 None => {}
             }

--- a/src/clash.rs
+++ b/src/clash.rs
@@ -43,3 +43,6 @@ pub use strength::*;
 
 mod defenses;
 pub use defenses::*;
+
+mod temperature;
+pub use temperature::*;

--- a/src/clash.rs
+++ b/src/clash.rs
@@ -46,3 +46,6 @@ pub use defenses::*;
 
 mod temperature;
 pub use temperature::*;
+
+mod tick_timer;
+pub use tick_timer::*;

--- a/src/clash/character_info.rs
+++ b/src/clash/character_info.rs
@@ -1,14 +1,15 @@
 use serde::{Deserialize, Serialize};
 
-use super::Defenses;
+use super::{Defenses, Temperature};
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct CharacterInfo {
     pub defenses: Defenses,
+    pub temperature: Temperature,
 }
 
 impl CharacterInfo {
-    pub fn init(defenses: Defenses) -> CharacterInfo {
-        CharacterInfo { defenses }
+    pub fn init(defenses: Defenses, temperature: Temperature) -> CharacterInfo {
+        CharacterInfo { defenses, temperature }
     }
 }

--- a/src/clash/combat.rs
+++ b/src/clash/combat.rs
@@ -97,13 +97,21 @@ pub fn start_bolt(ecs: &mut World, source: Entity) {
     ecs.raise_event(EventKind::Bolt(BoltState::BeginFlyingAnimation), Some(bolt));
 }
 
-fn apply_damage_to_location(ecs: &mut World, position: Point, damage: Damage) {
+pub fn apply_damage_to_location(ecs: &mut World, position: Point, damage: Damage) {
     if let Some(target) = find_character_at_location(ecs, position) {
-        let mut character_infos = ecs.write_storage::<CharacterInfoComponent>();
-        let defenses = &mut character_infos.grab_mut(target).character.defenses;
-        let mut random = &mut ecs.fetch_mut::<RandomComponent>().rand;
-        defenses.apply_damage(damage, &mut random);
+        apply_damage_to_character(ecs, damage, &target);
     }
+}
+
+pub fn apply_damage_to_character(ecs: &mut World, damage: Damage, target: &Entity) {
+    let mut character_infos = ecs.write_storage::<CharacterInfoComponent>();
+    apply_damage(damage, character_infos.grab_mut(*target), &mut ecs.fetch_mut::<RandomComponent>());
+}
+
+pub fn apply_damage(damage: Damage, character_info: &mut CharacterInfoComponent, random: &mut RandomComponent) {
+    let defenses = &mut character_info.character.defenses;
+    let mut random = &mut random.rand;
+    defenses.apply_damage(damage, &mut random);
 }
 
 pub fn apply_bolt(ecs: &mut World, bolt: Entity) {

--- a/src/clash/combat.rs
+++ b/src/clash/combat.rs
@@ -105,13 +105,8 @@ pub fn apply_damage_to_location(ecs: &mut World, position: Point, damage: Damage
 
 pub fn apply_damage_to_character(ecs: &mut World, damage: Damage, target: &Entity) {
     let mut character_infos = ecs.write_storage::<CharacterInfoComponent>();
-    apply_damage(damage, character_infos.grab_mut(*target), &mut ecs.fetch_mut::<RandomComponent>());
-}
-
-pub fn apply_damage(damage: Damage, character_info: &mut CharacterInfoComponent, random: &mut RandomComponent) {
-    let defenses = &mut character_info.character.defenses;
-    let mut random = &mut random.rand;
-    defenses.apply_damage(damage, &mut random);
+    let defenses = &mut character_infos.grab_mut(*target).character.defenses;
+    defenses.apply_damage(damage, &mut ecs.fetch_mut::<RandomComponent>().rand);
 }
 
 pub fn apply_bolt(ecs: &mut World, bolt: Entity) {

--- a/src/clash/combat.rs
+++ b/src/clash/combat.rs
@@ -104,9 +104,12 @@ pub fn apply_damage_to_location(ecs: &mut World, position: Point, damage: Damage
 }
 
 pub fn apply_damage_to_character(ecs: &mut World, damage: Damage, target: &Entity) {
-    let mut character_infos = ecs.write_storage::<CharacterInfoComponent>();
-    let defenses = &mut character_infos.grab_mut(*target).character.defenses;
-    defenses.apply_damage(damage, &mut ecs.fetch_mut::<RandomComponent>().rand);
+    let applied_damage = {
+        let mut character_infos = ecs.write_storage::<CharacterInfoComponent>();
+        let defenses = &mut character_infos.grab_mut(*target).character.defenses;
+        defenses.apply_damage(damage, &mut ecs.fetch_mut::<RandomComponent>().rand)
+    };
+    ecs.raise_event(EventKind::Damage(applied_damage, damage.kind), Some(*target));
 }
 
 pub fn apply_bolt(ecs: &mut World, bolt: Entity) {

--- a/src/clash/components.rs
+++ b/src/clash/components.rs
@@ -11,7 +11,7 @@ use specs_derive::*;
 use super::EventCoordinator;
 use super::Log;
 use crate::atlas::{EasyECS, Point, SizedPoint, ToSerialize};
-use crate::clash::{AmmoKind, AttackInfo, BehaviorKind, CharacterInfo, Defenses, Map};
+use crate::clash::{AmmoKind, AttackInfo, BehaviorKind, CharacterInfo, Defenses, Map, Temperature};
 
 #[derive(Hash, PartialEq, Eq, Component, ConvertSaveload, Clone)]
 pub struct TimeComponent {
@@ -222,6 +222,7 @@ pub fn create_world() -> World {
 pub trait ShortInfo {
     fn get_position(&self, entity: &Entity) -> SizedPoint;
     fn get_defenses(&self, entity: &Entity) -> Defenses;
+    fn get_temperature(&self, entity: &Entity) -> Temperature;
 }
 
 impl ShortInfo for World {
@@ -230,6 +231,9 @@ impl ShortInfo for World {
     }
     fn get_defenses(&self, entity: &Entity) -> Defenses {
         self.read_storage::<CharacterInfoComponent>().grab(*entity).character.defenses.clone()
+    }
+    fn get_temperature(&self, entity: &Entity) -> Temperature {
+        self.read_storage::<CharacterInfoComponent>().grab(*entity).character.temperature.clone()
     }
 }
 

--- a/src/clash/components.rs
+++ b/src/clash/components.rs
@@ -209,6 +209,7 @@ pub fn create_world() -> World {
     ecs.subscribe(super::combat::explode_event);
     ecs.subscribe(super::defenses::defense_event);
     ecs.subscribe(super::skills::tick_event);
+    ecs.subscribe(super::temperature::tick_event);
 
     #[cfg(test)]
     {

--- a/src/clash/components.rs
+++ b/src/clash/components.rs
@@ -208,6 +208,7 @@ pub fn create_world() -> World {
     ecs.subscribe(super::combat::field_event);
     ecs.subscribe(super::combat::explode_event);
     ecs.subscribe(super::defenses::defense_event);
+    ecs.subscribe(super::skills::tick_event);
 
     #[cfg(test)]
     {

--- a/src/clash/components.rs
+++ b/src/clash/components.rs
@@ -209,7 +209,7 @@ pub fn create_world() -> World {
     ecs.subscribe(super::combat::explode_event);
     ecs.subscribe(super::defenses::defense_event);
     ecs.subscribe(super::skills::tick_event);
-    ecs.subscribe(super::temperature::tick_event);
+    ecs.subscribe(super::temperature::temp_event);
 
     #[cfg(test)]
     {

--- a/src/clash/defenses.rs
+++ b/src/clash/defenses.rs
@@ -17,6 +17,7 @@ pub struct Defenses {
 }
 
 impl Defenses {
+    #[allow(dead_code)]
     pub fn init(dodge: u32, armor: u32, absorb: u32, health: u32) -> Defenses {
         Defenses {
             dodge,

--- a/src/clash/events.rs
+++ b/src/clash/events.rs
@@ -43,6 +43,7 @@ pub enum EventKind {
     Melee(MeleeState),
     Field(FieldState),
     Explode(ExplodeState),
+    Tick(i32),
 }
 
 type EventCallback = fn(ecs: &mut World, kind: EventKind, target: Option<Entity>) -> ();

--- a/src/clash/events.rs
+++ b/src/clash/events.rs
@@ -1,6 +1,8 @@
 use specs::prelude::*;
 use specs_derive::Component;
 
+use super::DamageKind;
+
 #[derive(Copy, Clone, is_enum_variant)]
 pub enum MoveState {
     BeginAnimation,
@@ -44,6 +46,7 @@ pub enum EventKind {
     Field(FieldState),
     Explode(ExplodeState),
     Tick(i32),
+    Damage(u32, DamageKind),
 }
 
 type EventCallback = fn(ecs: &mut World, kind: EventKind, target: Option<Entity>) -> ();

--- a/src/clash/skills.rs
+++ b/src/clash/skills.rs
@@ -763,7 +763,9 @@ mod tests {
     fn dodge_restored_by_skill_movement() {
         let mut ecs = create_test_state().with_character(2, 2, 100).with_map().build();
         let entity = find_at(&ecs, 2, 2);
-        ecs.write_storage::<CharacterInfoComponent>().grab_mut(entity).character.defenses = Defenses::init(0, 5, 0, 0, 10);
+        let mut defenses = Defenses::just_health(10);
+        defenses.max_dodge = 5;
+        ecs.write_storage::<CharacterInfoComponent>().grab_mut(entity).character.defenses = defenses;
 
         invoke_skill(&mut ecs, &entity, "TestMove", Some(Point::init(3, 3)));
         wait_for_animations(&mut ecs);

--- a/src/clash/skills.rs
+++ b/src/clash/skills.rs
@@ -1,8 +1,10 @@
+use std::cmp;
 use std::collections::HashMap;
 use std::slice::from_ref;
 
 use enum_iterator::IntoEnumIterator;
 use lazy_static::lazy_static;
+use ordered_float::*;
 use serde::{Deserialize, Serialize};
 use specs::prelude::*;
 
@@ -405,11 +407,33 @@ fn reload(ecs: &mut World, invoker: &Entity, kind: AmmoKind) {
     set_ammo(ecs, invoker, kind, max_ammo);
 }
 
+fn add_ticks_for_skill(skill: &mut SkillResourceComponent, ticks_to_add: i32) {
+    let exhaustion_to_remove = EXHAUSTION_PER_100_TICKS as f64 * (ticks_to_add as f64 / 100.0);
+
+    let focus_to_add = FOCUS_PER_100_TICKS as f64 * (ticks_to_add as f64 / 100.0);
+    // Ordering f64 is hard _tm_
+    skill.exhaustion = *cmp::max(NotNan::new(0.0).unwrap(), NotNan::new(skill.exhaustion - exhaustion_to_remove).unwrap());
+    skill.focus = *cmp::min(NotNan::new(skill.max_focus).unwrap(), NotNan::new(skill.focus + focus_to_add).unwrap());
+}
+
+pub fn tick_event(ecs: &mut World, kind: EventKind, target: Option<Entity>) {
+    match kind {
+        EventKind::Tick(ticks) => {
+            let mut skills = ecs.write_storage::<SkillResourceComponent>();
+            if let Some(skill_resource) = skills.get_mut(target.unwrap()) {
+                add_ticks_for_skill(skill_resource, ticks);
+            }
+        }
+        _ => {}
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::{add_ticks, create_test_state, find_at, find_first_entity, get_ticks, wait_for_animations};
     use super::*;
     use crate::atlas::{EasyMutWorld, SizedPoint};
+    use assert_approx_eq::assert_approx_eq;
 
     #[test]
     #[should_panic]
@@ -746,5 +770,57 @@ mod tests {
 
         let dodge = ecs.read_storage::<CharacterInfoComponent>().grab(entity).character.defenses.dodge;
         assert_eq!(4, dodge);
+    }
+
+    #[test]
+    fn exhaustion_reduced_by_time() {
+        let mut ecs = create_test_state().with_character(2, 2, 100).with_map().build();
+        let player = find_at(&ecs, 2, 2);
+        ecs.write_storage::<SkillResourceComponent>().grab_mut(player).exhaustion = 50.0;
+        // This works as long as there is no rounding, as 20 *(5 *.5) = 50.0
+        for _ in 0..20 {
+            add_ticks(&mut ecs, 50);
+        }
+
+        {
+            let skills = ecs.read_storage::<SkillResourceComponent>();
+            assert_approx_eq!(skills.grab(player).exhaustion, 0.0);
+        }
+
+        // Keep going, make sure it doesn't drop below zero
+        for _ in 0..10 {
+            add_ticks(&mut ecs, 100);
+        }
+
+        {
+            let skills = ecs.read_storage::<SkillResourceComponent>();
+            assert_approx_eq!(skills.grab(player).exhaustion, 0.0);
+        }
+    }
+
+    #[test]
+    fn focus_restored_by_time() {
+        let mut ecs = create_test_state().with_character(2, 2, 100).with_map().build();
+        let player = find_at(&ecs, 2, 2);
+        ecs.write_storage::<SkillResourceComponent>().grab_mut(player).focus = 0.0;
+        ecs.write_storage::<SkillResourceComponent>().grab_mut(player).max_focus = 1.0;
+        for _ in 0..20 {
+            add_ticks(&mut ecs, 50);
+        }
+
+        {
+            let skills = ecs.read_storage::<SkillResourceComponent>();
+            assert_approx_eq!(skills.grab(player).focus, 1.0);
+        }
+
+        // Keep going, make sure it doesn't go above max
+        for _ in 0..10 {
+            add_ticks(&mut ecs, 100);
+        }
+
+        {
+            let skills = ecs.read_storage::<SkillResourceComponent>();
+            assert_approx_eq!(skills.grab(player).focus, 1.0);
+        }
     }
 }

--- a/src/clash/strength.rs
+++ b/src/clash/strength.rs
@@ -25,6 +25,7 @@ impl Strength {
 #[derive(Clone, Copy, Deserialize, Serialize)]
 pub enum DamageKind {
     Physical,
+    Heat,
 }
 
 #[derive(Clone, Copy, Deserialize, Serialize)]
@@ -40,6 +41,10 @@ impl Damage {
 
     pub fn physical(amount: u32) -> Damage {
         Damage::init(Strength::init(amount), DamageKind::Physical)
+    }
+
+    pub fn heat(amount: u32) -> Damage {
+        Damage::init(Strength::init(amount), DamageKind::Heat)
     }
 
     pub fn dice(&self) -> u32 {

--- a/src/clash/strength.rs
+++ b/src/clash/strength.rs
@@ -25,7 +25,7 @@ impl Strength {
 #[derive(Clone, Copy, Deserialize, Serialize)]
 pub enum DamageKind {
     Physical,
-    Heat,
+    Fire,
 }
 
 #[derive(Clone, Copy, Deserialize, Serialize)]
@@ -43,8 +43,8 @@ impl Damage {
         Damage::init(Strength::init(amount), DamageKind::Physical)
     }
 
-    pub fn heat(amount: u32) -> Damage {
-        Damage::init(Strength::init(amount), DamageKind::Heat)
+    pub fn fire(amount: u32) -> Damage {
+        Damage::init(Strength::init(amount), DamageKind::Fire)
     }
 
     pub fn dice(&self) -> u32 {

--- a/src/clash/temperature.rs
+++ b/src/clash/temperature.rs
@@ -104,7 +104,7 @@ pub fn temp_event(ecs: &mut World, kind: EventKind, target: Option<Entity>) {
 mod tests {
     use super::super::*;
     use super::*;
-    use crate::atlas::{EasyECS, EasyMutECS, Point};
+    use crate::atlas::{EasyMutECS, Point};
 
     #[test]
     fn apply_temperature_based_upon_damage_dice() {

--- a/src/clash/temperature.rs
+++ b/src/clash/temperature.rs
@@ -1,13 +1,19 @@
 use std::cmp;
 
-use super::{BASE_ACTION_COST, STRENGTH_DICE_SIDES};
+use serde::{Deserialize, Serialize};
+use specs::prelude::*;
+
+use super::*;
+use crate::atlas::{EasyECS, EasyMutECS};
 
 const TEMPERATURE_MIDPOINT: i32 = 0;
 const TEMPERATURE_BURN_POINT: i32 = 100;
-const TEMPERATURE_BASE_POINT: i32 = -100;
+const TEMPERATURE_FREEZE_POINT: i32 = -100;
 
-struct Temperature {
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Temperature {
     current_temperature: i32,
+    timer: TickTimer,
 }
 
 pub enum TemperatureDirection {
@@ -19,10 +25,11 @@ impl Temperature {
     pub fn init() -> Temperature {
         Temperature {
             current_temperature: TEMPERATURE_MIDPOINT,
+            timer: TickTimer::init(),
         }
     }
 
-    pub fn apply_damage(&mut self, damage: u32, direction: TemperatureDirection) {
+    pub fn change_from_incoming_damage(&mut self, damage: u32, direction: TemperatureDirection) {
         // 4 strength 10 shots half resisted should tip us over (20 dice)
         // Default range 100 / 20 = 5 temperature per dice
         const TEMPERATURE_PER_DICE_DAMAGE: i32 = 5;
@@ -35,61 +42,133 @@ impl Temperature {
         self.current_temperature += delta;
     }
 
-    pub fn reduce_temperature(&mut self, ticks: u32) {
+    pub fn reduce_temperature(&mut self) {
         // 8 turns should be enough to go from 100 -> 0 or -100 -> 0
         // 100 / 8 = 13
         const TEMPERATURE_LOST_PER_TURN: i32 = 13;
-        let delta = ((TEMPERATURE_LOST_PER_TURN as f32 * ticks as f32) / (BASE_ACTION_COST as f32)).round();
 
         if self.current_temperature > TEMPERATURE_MIDPOINT {
-            self.current_temperature = cmp::max(self.current_temperature - (delta as i32), 0);
+            self.current_temperature = cmp::max(self.current_temperature - TEMPERATURE_LOST_PER_TURN, 0);
         } else {
-            self.current_temperature = cmp::min(self.current_temperature + (delta as i32), 0);
+            self.current_temperature = cmp::min(self.current_temperature + TEMPERATURE_LOST_PER_TURN, 0);
         }
+    }
+
+    pub fn is_ready(&mut self, ticks_to_add: i32) -> bool {
+        self.timer.apply_ticks(ticks_to_add)
+    }
+}
+
+fn apply_temperature_effects(character_info: &mut CharacterInfoComponent, random: &mut RandomComponent) {
+    let current_temperature = character_info.character.temperature.current_temperature;
+
+    if current_temperature > TEMPERATURE_BURN_POINT {
+        const TEMPERATURE_DAMAGE_PER_TICK: u32 = 2;
+        apply_damage(Damage::heat(TEMPERATURE_DAMAGE_PER_TICK), character_info, random);
+    } else if current_temperature < TEMPERATURE_FREEZE_POINT {
+    }
+}
+
+pub fn tick_event(ecs: &mut World, kind: EventKind, target: Option<Entity>) {
+    match kind {
+        EventKind::Tick(ticks) => {
+            let mut character_infos = ecs.write_storage::<CharacterInfoComponent>();
+            if let Some(character_info) = &mut character_infos.get_mut(target.unwrap()) {
+                if character_info.character.temperature.is_ready(ticks) {
+                    apply_temperature_effects(character_info, &mut ecs.fetch_mut::<RandomComponent>());
+                    character_info.character.temperature.reduce_temperature();
+                }
+            }
+        }
+        _ => {}
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::super::*;
     use super::*;
+    use crate::atlas::EasyMutECS;
 
     #[test]
     fn apply_temperature_based_upon_damage_dice() {
         let mut temperature = Temperature::init();
-        temperature.apply_damage(50, TemperatureDirection::Heat);
+        temperature.change_from_incoming_damage(50, TemperatureDirection::Heat);
         assert!(temperature.current_temperature > TEMPERATURE_MIDPOINT);
     }
 
     #[test]
     fn apply_temperature_can_reverse_others() {
         let mut temperature = Temperature::init();
-        temperature.apply_damage(50, TemperatureDirection::Heat);
-        temperature.apply_damage(100, TemperatureDirection::Cool);
+        temperature.change_from_incoming_damage(50, TemperatureDirection::Heat);
+        temperature.change_from_incoming_damage(100, TemperatureDirection::Cool);
         assert!(temperature.current_temperature < TEMPERATURE_MIDPOINT);
     }
 
     #[test]
     fn temperature_reduction_towards_average() {
         let mut temperature = Temperature::init();
-        temperature.apply_damage(50, TemperatureDirection::Heat);
+        temperature.change_from_incoming_damage(50, TemperatureDirection::Heat);
         let initial = temperature.current_temperature;
-        temperature.reduce_temperature(100);
+        temperature.reduce_temperature();
         assert!(temperature.current_temperature < initial);
     }
 
     #[test]
     fn temperature_reduction_does_not_overshoot() {
-        let mut temperature = Temperature { current_temperature: 5 };
-        temperature.reduce_temperature(100);
+        let mut temperature = Temperature {
+            current_temperature: 5,
+            timer: TickTimer::init(),
+        };
+        temperature.reduce_temperature();
         assert_eq!(0, temperature.current_temperature);
     }
 
     #[test]
-    fn temperature_can_cause_burns() {}
+    fn temperature_can_cause_burns() {
+        let mut ecs = create_test_state().with_character(2, 2, 100).with_map().build();
+        let player = find_at(&ecs, 2, 2);
+        ecs.write_storage::<CharacterInfoComponent>()
+            .grab_mut(player)
+            .character
+            .temperature
+            .current_temperature = TEMPERATURE_BURN_POINT + 10;
+
+        let starting_health = ecs.get_defenses(&player).health;
+        add_ticks(&mut ecs, 100);
+        assert!(ecs.get_defenses(&player).health < starting_health);
+    }
 
     #[test]
     fn temperature_can_cause_frost() {}
 
     #[test]
-    fn reductions_happen_over_game_turns() {}
+    fn reductions_happen_over_game_turns() {
+        let mut ecs = create_test_state().with_character(2, 2, 100).with_map().build();
+        let player = find_at(&ecs, 2, 2);
+        ecs.write_storage::<CharacterInfoComponent>()
+            .grab_mut(player)
+            .character
+            .temperature
+            .current_temperature = TEMPERATURE_BURN_POINT + 10;
+
+        let starting_temp = ecs
+            .read_storage::<CharacterInfoComponent>()
+            .grab(player)
+            .character
+            .temperature
+            .current_temperature;
+        add_ticks(&mut ecs, 100);
+        assert!(
+            ecs.read_storage::<CharacterInfoComponent>()
+                .grab(player)
+                .character
+                .temperature
+                .current_temperature
+                < starting_temp
+        );
+    }
+
+    #[test]
+    fn ranged_attack_adds_temperature() {}
 }

--- a/src/clash/temperature.rs
+++ b/src/clash/temperature.rs
@@ -179,7 +179,7 @@ mod tests {
         let player = find_at(&ecs, 2, 2);
         let target = find_at(&ecs, 3, 2);
         // Prevent target from dying
-        ecs.write_storage::<CharacterInfoComponent>().grab_mut(target).character.defenses = Defenses::init(0, 0, 0, 0, 200);
+        ecs.write_storage::<CharacterInfoComponent>().grab_mut(target).character.defenses = Defenses::just_health(200);
 
         for _ in 0..4 {
             begin_bolt(&mut ecs, &player, Point::init(3, 2), Damage::fire(10), BoltKind::Fire);

--- a/src/clash/temperature.rs
+++ b/src/clash/temperature.rs
@@ -1,0 +1,95 @@
+use std::cmp;
+
+use super::{BASE_ACTION_COST, STRENGTH_DICE_SIDES};
+
+const TEMPERATURE_MIDPOINT: i32 = 0;
+const TEMPERATURE_BURN_POINT: i32 = 100;
+const TEMPERATURE_BASE_POINT: i32 = -100;
+
+struct Temperature {
+    current_temperature: i32,
+}
+
+pub enum TemperatureDirection {
+    Heat,
+    Cool,
+}
+
+impl Temperature {
+    pub fn init() -> Temperature {
+        Temperature {
+            current_temperature: TEMPERATURE_MIDPOINT,
+        }
+    }
+
+    pub fn apply_damage(&mut self, damage: u32, direction: TemperatureDirection) {
+        // 4 strength 10 shots half resisted should tip us over (20 dice)
+        // Default range 100 / 20 = 5 temperature per dice
+        const TEMPERATURE_PER_DICE_DAMAGE: i32 = 5;
+        let dice: i32 = (damage / STRENGTH_DICE_SIDES) as i32;
+
+        let delta = match direction {
+            TemperatureDirection::Heat => dice * TEMPERATURE_PER_DICE_DAMAGE,
+            TemperatureDirection::Cool => -1 * dice * TEMPERATURE_PER_DICE_DAMAGE,
+        };
+        self.current_temperature += delta;
+    }
+
+    pub fn reduce_temperature(&mut self, ticks: u32) {
+        // 8 turns should be enough to go from 100 -> 0 or -100 -> 0
+        // 100 / 8 = 13
+        const TEMPERATURE_LOST_PER_TURN: i32 = 13;
+        let delta = ((TEMPERATURE_LOST_PER_TURN as f32 * ticks as f32) / (BASE_ACTION_COST as f32)).round();
+
+        if self.current_temperature > TEMPERATURE_MIDPOINT {
+            self.current_temperature = cmp::max(self.current_temperature - (delta as i32), 0);
+        } else {
+            self.current_temperature = cmp::min(self.current_temperature + (delta as i32), 0);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn apply_temperature_based_upon_damage_dice() {
+        let mut temperature = Temperature::init();
+        temperature.apply_damage(50, TemperatureDirection::Heat);
+        assert!(temperature.current_temperature > TEMPERATURE_MIDPOINT);
+    }
+
+    #[test]
+    fn apply_temperature_can_reverse_others() {
+        let mut temperature = Temperature::init();
+        temperature.apply_damage(50, TemperatureDirection::Heat);
+        temperature.apply_damage(100, TemperatureDirection::Cool);
+        assert!(temperature.current_temperature < TEMPERATURE_MIDPOINT);
+    }
+
+    #[test]
+    fn temperature_reduction_towards_average() {
+        let mut temperature = Temperature::init();
+        temperature.apply_damage(50, TemperatureDirection::Heat);
+        let initial = temperature.current_temperature;
+        temperature.reduce_temperature(100);
+        assert!(temperature.current_temperature < initial);
+    }
+
+    #[test]
+    fn temperature_reduction_does_not_overshoot() {
+        let mut temperature = Temperature { current_temperature: 5 };
+        temperature.reduce_temperature(100);
+        assert_eq!(0, temperature.current_temperature);
+    }
+
+    #[test]
+    fn temperature_can_cause_burns() {}
+
+    #[test]
+    fn temperature_can_cause_frost() {}
+
+    #[test]
+    fn reductions_happen_over_game_turns() {}
+}

--- a/src/clash/temperature.rs
+++ b/src/clash/temperature.rs
@@ -4,7 +4,6 @@ use serde::{Deserialize, Serialize};
 use specs::prelude::*;
 
 use super::*;
-use crate::atlas::{EasyECS, EasyMutECS};
 
 const TEMPERATURE_MIDPOINT: i32 = 0;
 const TEMPERATURE_BURN_POINT: i32 = 100;
@@ -18,6 +17,7 @@ pub struct Temperature {
 
 pub enum TemperatureDirection {
     Heat,
+    #[allow(dead_code)]
     Cool,
 }
 
@@ -37,7 +37,7 @@ impl Temperature {
 
         let delta = match direction {
             TemperatureDirection::Heat => dice * TEMPERATURE_PER_DICE_DAMAGE,
-            TemperatureDirection::Cool => -1 * dice * TEMPERATURE_PER_DICE_DAMAGE,
+            TemperatureDirection::Cool => -dice * TEMPERATURE_PER_DICE_DAMAGE,
         };
         self.current_temperature += delta;
     }
@@ -104,7 +104,7 @@ pub fn temp_event(ecs: &mut World, kind: EventKind, target: Option<Entity>) {
 mod tests {
     use super::super::*;
     use super::*;
-    use crate::atlas::{EasyMutECS, Point};
+    use crate::atlas::{EasyECS, EasyMutECS, Point};
 
     #[test]
     fn apply_temperature_based_upon_damage_dice() {

--- a/src/clash/temperature.rs
+++ b/src/clash/temperature.rs
@@ -12,7 +12,7 @@ const TEMPERATURE_FREEZE_POINT: i32 = -100;
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Temperature {
-    current_temperature: i32,
+    pub current_temperature: i32,
     timer: TickTimer,
 }
 

--- a/src/clash/test_helpers.rs
+++ b/src/clash/test_helpers.rs
@@ -80,7 +80,10 @@ pub fn make_test_character(ecs: &mut World, position: SizedPoint, time: i32) {
     ecs.create_entity()
         .with(TimeComponent::init(time))
         .with(PositionComponent::init(position))
-        .with(CharacterInfoComponent::init(CharacterInfo::init(Defenses::init(0, 0, 0, 0, 10))))
+        .with(CharacterInfoComponent::init(CharacterInfo::init(
+            Defenses::init(0, 0, 0, 0, 10),
+            Temperature::init(),
+        )))
         .with(SkillResourceComponent::init(&[]))
         .build();
 }

--- a/src/clash/test_helpers.rs
+++ b/src/clash/test_helpers.rs
@@ -81,7 +81,7 @@ pub fn make_test_character(ecs: &mut World, position: SizedPoint, time: i32) {
         .with(TimeComponent::init(time))
         .with(PositionComponent::init(position))
         .with(CharacterInfoComponent::init(CharacterInfo::init(
-            Defenses::init(0, 0, 0, 0, 10),
+            Defenses::just_health(10),
             Temperature::init(),
         )))
         .with(SkillResourceComponent::init(&[]))

--- a/src/clash/tick_timer.rs
+++ b/src/clash/tick_timer.rs
@@ -28,9 +28,7 @@ impl TickTimer {
 
 #[cfg(test)]
 mod tests {
-    use super::super::*;
     use super::*;
-    use crate::atlas::EasyMutECS;
 
     #[test]
     fn large_ticks() {

--- a/src/clash/tick_timer.rs
+++ b/src/clash/tick_timer.rs
@@ -1,0 +1,59 @@
+use serde::{Deserialize, Serialize};
+
+use super::BASE_ACTION_COST;
+
+// Track how long since last proc, since ticks can be offset of BASE_ACTION_COST
+#[derive(Serialize, Deserialize, Clone)]
+pub struct TickTimer {
+    ticks: i32,
+}
+
+impl TickTimer {
+    pub fn init() -> TickTimer {
+        TickTimer { ticks: 0 }
+    }
+
+    pub fn apply_ticks(&mut self, ticks_to_add: i32) -> bool {
+        self.ticks += ticks_to_add;
+        // We don't handle double wrap around
+        assert!(self.ticks < (BASE_ACTION_COST * 2));
+        if self.ticks >= BASE_ACTION_COST {
+            self.ticks -= BASE_ACTION_COST;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::*;
+    use super::*;
+    use crate::atlas::EasyMutECS;
+
+    #[test]
+    fn large_ticks() {
+        let mut timer = TickTimer::init();
+        assert!(timer.apply_ticks(100));
+        assert!(timer.apply_ticks(100));
+        assert!(timer.apply_ticks(100));
+    }
+
+    #[test]
+    fn multiple_small_ticks() {
+        let mut timer = TickTimer::init();
+        assert_eq!(false, timer.apply_ticks(50));
+        assert_eq!(true, timer.apply_ticks(50));
+        assert_eq!(false, timer.apply_ticks(30));
+        assert_eq!(false, timer.apply_ticks(30));
+        assert_eq!(true, timer.apply_ticks(40));
+    }
+
+    #[test]
+    #[should_panic]
+    fn double_wrap_asserts() {
+        let mut timer = TickTimer::init();
+        timer.apply_ticks(200);
+    }
+}

--- a/src/clash/time.rs
+++ b/src/clash/time.rs
@@ -1,10 +1,8 @@
-use std::cmp;
 use std::collections::BTreeMap;
 
-use ordered_float::*;
 use specs::prelude::*;
 
-use super::{SkillResourceComponent, TimeComponent};
+use super::{EventCoordinator, EventKind, TimeComponent};
 use crate::atlas::{EasyECS, EasyMutECS};
 
 pub const BASE_ACTION_COST: i32 = 100;
@@ -31,23 +29,18 @@ pub const EXHAUSTION_COST_PER_MOVE: f64 = 5.0;
 pub const FOCUS_PER_100_TICKS: f64 = 0.1;
 
 pub fn add_ticks(ecs: &mut World, ticks_to_add: i32) {
-    let mut times = ecs.write_storage::<TimeComponent>();
-    let mut skills = ecs.write_storage::<SkillResourceComponent>();
-    for (time, skill) in (&mut times, (&mut skills).maybe()).join() {
-        time.ticks += ticks_to_add;
-        if let Some(skill) = skill {
-            add_ticks_for_skill(skill, ticks_to_add);
+    let mut elements = vec![];
+    {
+        let entities = ecs.read_resource::<specs::world::EntitiesRes>();
+        let mut times = ecs.write_storage::<TimeComponent>();
+        for (entity, time) in (&entities, &mut times).join() {
+            time.ticks += ticks_to_add;
+            elements.push(entity);
         }
     }
-}
-
-fn add_ticks_for_skill(skill: &mut SkillResourceComponent, ticks_to_add: i32) {
-    let exhaustion_to_remove = EXHAUSTION_PER_100_TICKS as f64 * (ticks_to_add as f64 / 100.0);
-
-    let focus_to_add = FOCUS_PER_100_TICKS as f64 * (ticks_to_add as f64 / 100.0);
-    // Ordering f64 is hard _tm_
-    skill.exhaustion = *cmp::max(NotNan::new(0.0).unwrap(), NotNan::new(skill.exhaustion - exhaustion_to_remove).unwrap());
-    skill.focus = *cmp::min(NotNan::new(skill.max_focus).unwrap(), NotNan::new(skill.focus + focus_to_add).unwrap());
+    for e in elements {
+        ecs.raise_event(EventKind::Tick(ticks_to_add), Some(e));
+    }
 }
 
 pub fn wait_for_next(ecs: &mut World) -> Option<Entity> {
@@ -74,8 +67,6 @@ pub fn spend_time(ecs: &mut World, element: &Entity, ticks_to_spend: i32) {
 
 #[cfg(test)]
 mod tests {
-    use assert_approx_eq::assert_approx_eq;
-
     use super::super::{create_test_state, create_world, find_all_entities, find_at, find_at_time, find_first_entity, SkillResourceComponent};
     use super::*;
 
@@ -142,57 +133,5 @@ mod tests {
         let first = find_first_entity(&ecs);
         spend_time(&mut ecs, &first, BASE_ACTION_COST);
         assert_eq!(10, get_ticks(&ecs, &first));
-    }
-
-    #[test]
-    fn add_ticks_reduces_exhaustion() {
-        let mut ecs = create_test_state().with_character(2, 2, 100).with_map().build();
-        let player = find_at(&ecs, 2, 2);
-        ecs.write_storage::<SkillResourceComponent>().grab_mut(player).exhaustion = 50.0;
-        // This works as long as there is no rounding, as 20 *(5 *.5) = 50.0
-        for _ in 0..20 {
-            add_ticks(&mut ecs, 50);
-        }
-
-        {
-            let skills = ecs.read_storage::<SkillResourceComponent>();
-            assert_approx_eq!(skills.grab(player).exhaustion, 0.0);
-        }
-
-        // Keep going, make sure it doesn't drop below zero
-        for _ in 0..10 {
-            add_ticks(&mut ecs, 100);
-        }
-
-        {
-            let skills = ecs.read_storage::<SkillResourceComponent>();
-            assert_approx_eq!(skills.grab(player).exhaustion, 0.0);
-        }
-    }
-
-    #[test]
-    fn add_ticks_increases_focus() {
-        let mut ecs = create_test_state().with_character(2, 2, 100).with_map().build();
-        let player = find_at(&ecs, 2, 2);
-        ecs.write_storage::<SkillResourceComponent>().grab_mut(player).focus = 0.0;
-        ecs.write_storage::<SkillResourceComponent>().grab_mut(player).max_focus = 1.0;
-        for _ in 0..20 {
-            add_ticks(&mut ecs, 50);
-        }
-
-        {
-            let skills = ecs.read_storage::<SkillResourceComponent>();
-            assert_approx_eq!(skills.grab(player).focus, 1.0);
-        }
-
-        // Keep going, make sure it doesn't go above max
-        for _ in 0..10 {
-            add_ticks(&mut ecs, 100);
-        }
-
-        {
-            let skills = ecs.read_storage::<SkillResourceComponent>();
-            assert_approx_eq!(skills.grab(player).focus, 1.0);
-        }
     }
 }

--- a/src/clash/time.rs
+++ b/src/clash/time.rs
@@ -67,7 +67,7 @@ pub fn spend_time(ecs: &mut World, element: &Entity, ticks_to_spend: i32) {
 
 #[cfg(test)]
 mod tests {
-    use super::super::{create_test_state, create_world, find_all_entities, find_at, find_at_time, find_first_entity, SkillResourceComponent};
+    use super::super::{create_test_state, create_world, find_all_entities, find_at_time, find_first_entity};
     use super::*;
 
     #[test]


### PR DESCRIPTION
- This implements a temperature system, where some attacks (Fire/Ice) can heat/cool enemies. Too much/too little heat will burn (damage) / frost (slow) enemies.
- Frost is not implemented yet due to lack of status effects.
- Fixup info bar to print other stats while we were at it
- Events for Tick and Damage
- https://github.com/chamons/ArenaGS/issues/162