### PR TITLE
Triple your shots with triple-mint gum 

### DIFF
--- a/src/arena/battle_actions.rs
+++ b/src/arena/battle_actions.rs
@@ -20,12 +20,9 @@ pub fn get_skill_name(ecs: &World, index: usize) -> Option<String> {
 pub fn get_current_skill(ecs: &World, skill_name: &str) -> String {
     let skill = get_skill(skill_name);
 
-    if skill.is_usable(ecs, &find_player(&ecs)) {
-        skill_name.to_string()
-    } else if let Some(alt_skill) = &skill.alternate {
-        alt_skill.to_string()
-    } else {
-        skill_name.to_string()
+    match skill.is_usable(ecs, &find_player(&ecs)) {
+        UsableResults::LacksAmmo if skill.alternate.is_some() => skill.alternate.as_ref().unwrap().to_string(),
+        _ => skill_name.to_string(),
     }
 }
 
@@ -36,8 +33,9 @@ pub fn select_skill(ecs: &mut World, name: &str) {
 
     let skill = get_skill(name);
 
-    if !skill.is_usable(ecs, &find_player(&ecs)) {
-        return;
+    match skill.is_usable(ecs, &find_player(&ecs)) {
+        UsableResults::Usable => {}
+        _ => return,
     }
 
     let target_required = skill.target;

--- a/src/arena/battle_animations.rs
+++ b/src/arena/battle_animations.rs
@@ -34,7 +34,7 @@ pub fn projectile_animation(ecs: &mut World, projectile: Entity, sprite: SpriteK
     let target_position = ecs.read_storage::<AttackComponent>().grab(projectile).attack.target;
 
     let path_length = source_position.distance_to(target_position).unwrap() as u64;
-    let animation_length = if frame < 4 { 4 * path_length } else { 2 * path_length };
+    let animation_length = if frame < 4 { 6 * path_length } else { 3 * path_length };
 
     let animation = Animation::movement(source_position.origin, target_position, frame, animation_length).with_post_event(post_event, Some(projectile));
     ecs.shovel(projectile, AnimationComponent::init(animation));

--- a/src/arena/spawner.rs
+++ b/src/arena/spawner.rs
@@ -38,7 +38,7 @@ pub fn bird_monster(ecs: &mut World) {
         .with(PositionComponent::init(SizedPoint::init_multi(5, 5, 2, 2)))
         .with(CharacterInfoComponent::init(CharacterInfo::init(
             "Giant Bird",
-            Defenses::just_health(25),
+            Defenses::just_health(150),
             Temperature::init(),
         )))
         .with(StatusComponent::init())

--- a/src/arena/sprite_loader.rs
+++ b/src/arena/sprite_loader.rs
@@ -5,6 +5,7 @@ use enum_iterator::IntoEnumIterator;
 use sdl2::rect::Point as SDLPoint;
 
 use super::components::*;
+use super::views::TILE_SIZE;
 use crate::after_image::*;
 use crate::atlas::BoxResult;
 
@@ -49,19 +50,15 @@ impl SpriteLoader {
                     1.5,
                 )?),
                 SpriteKinds::FireBolt => Box::new(Bolt::init(render_context, &SpriteFolderDescription::init_without_set(&folder, "fire"), 0, 4)?),
-                SpriteKinds::Bullet => Box::new(Bolt::init(
-                    render_context,
-                    &SpriteFolderDescription::init_without_set(&folder, "weapons_2"),
-                    6,
-                    1,
-                )?),
-                SpriteKinds::FireBullet => Box::new(Bolt::init(render_context, &SpriteFolderDescription::init_without_set(&folder, "fire"), 0, 4)?),
-                SpriteKinds::AirBullet => Box::new(Bolt::init(
-                    render_context,
-                    &SpriteFolderDescription::init_without_set(&folder, "weapons_2"),
-                    17,
-                    2,
-                )?),
+                SpriteKinds::Bullet => Box::new(
+                    Bolt::init(render_context, &SpriteFolderDescription::init_without_set(&folder, "weapons_2"), 6, 1)?.with_render_offset(bullet_offset()),
+                ),
+                SpriteKinds::FireBullet => {
+                    Box::new(Bolt::init(render_context, &SpriteFolderDescription::init_without_set(&folder, "fire"), 0, 4)?.with_render_offset(bullet_offset()))
+                }
+                SpriteKinds::AirBullet => Box::new(
+                    Bolt::init(render_context, &SpriteFolderDescription::init_without_set(&folder, "weapons_2"), 17, 2)?.with_render_offset(bullet_offset()),
+                ),
                 SpriteKinds::Bomb => Box::new(Bolt::init(render_context, &SpriteFolderDescription::init_without_set(&folder, "object"), 4, 2)?),
                 SpriteKinds::Explosion => Box::new(
                     Bolt::init(render_context, &SpriteFolderDescription::init_without_set(&folder, "explosion"), 11, 8)?
@@ -73,4 +70,8 @@ impl SpriteLoader {
         }
         Ok(sprites)
     }
+}
+
+fn bullet_offset() -> SDLPoint {
+    SDLPoint::new(0, (TILE_SIZE / 2) as i32)
 }

--- a/src/clash/combat.rs
+++ b/src/clash/combat.rs
@@ -2,8 +2,8 @@ use serde::{Deserialize, Serialize};
 use specs::prelude::*;
 
 use super::*;
-use crate::atlas::{EasyECS, EasyMutECS, EasyMutWorld, Point, SizedPoint};
-use crate::clash::{Direction, EventCoordinator, FieldComponent};
+use crate::atlas::{EasyECS, EasyMutWorld, Point, SizedPoint};
+use crate::clash::{EventCoordinator, FieldComponent};
 
 #[derive(Clone, Copy, Deserialize, Serialize)]
 pub enum FieldKind {
@@ -126,61 +126,6 @@ pub fn start_bolt(ecs: &mut World, source: Entity) {
 
     ecs.write_storage::<AttackComponent>().remove(source);
     ecs.raise_event(EventKind::Bolt(BoltState::BeginFlyingAnimation), Some(bolt));
-}
-
-pub fn apply_damage_to_location(ecs: &mut World, target_position: Point, source_position: Option<Point>, damage: Damage) {
-    if let Some(target) = find_character_at_location(ecs, target_position) {
-        apply_damage_to_character(ecs, damage, &target, source_position);
-    }
-}
-
-pub fn apply_damage_to_character(ecs: &mut World, damage: Damage, target: &Entity, source_position: Option<Point>) {
-    let rolled_damage = {
-        let mut character_infos = ecs.write_storage::<CharacterInfoComponent>();
-        let defenses = &mut character_infos.grab_mut(*target).character.defenses;
-        defenses.apply_damage(damage, &mut ecs.fetch_mut::<RandomComponent>().rand)
-    };
-    ecs.log(format!(
-        "{} took {} damage (Str {}).",
-        ecs.get_name(&target).unwrap().as_str(),
-        rolled_damage.amount,
-        damage.dice()
-    ));
-
-    if rolled_damage.options.contains(DamageOptions::KNOCKBACK) {
-        if let Some(source_position) = source_position {
-            let current_position = ecs.get_position(target);
-            let direction_of_impact = Direction::from_two_points(&source_position, &current_position.origin);
-            if let Some(new_origin) = direction_of_impact.point_in_direction(&current_position.origin) {
-                let new_position = current_position.move_to(new_origin);
-                if is_area_clear(ecs, &new_position.all_positions(), target) {
-                    begin_move(ecs, target, new_position, PostMoveAction::None);
-                }
-            }
-        }
-    }
-    if rolled_damage.options.contains(DamageOptions::ADD_CHARGE_STATUS) {
-        ecs.log(format!("{} crackles with static electricity", ecs.get_name(target).unwrap()));
-        ecs.write_storage::<StatusComponent>()
-            .grab_mut(*target)
-            .status
-            .add_status(StatusKind::StaticCharge, 300);
-    }
-    if rolled_damage.options.contains(DamageOptions::CONSUMES_CHARGE) && ecs.has_status(target, StatusKind::StaticCharge) {
-        const STATIC_CHARGE_DAMAGE: u32 = 4;
-        apply_damage_to_character(
-            ecs,
-            Damage::init(STATIC_CHARGE_DAMAGE).with_option(DamageOptions::PIERCE_DEFENSES),
-            target,
-            None,
-        );
-        ecs.write_storage::<StatusComponent>()
-            .grab_mut(*target)
-            .status
-            .remove_status(StatusKind::StaticCharge);
-    }
-
-    ecs.raise_event(EventKind::Damage(rolled_damage), Some(*target));
 }
 
 pub fn apply_bolt(ecs: &mut World, bolt: Entity) {
@@ -468,120 +413,5 @@ mod tests {
         assert_position(&ecs, &player, Point::init(2, 1));
         assert_eq!(ecs.get_defenses(&target).health, starting_health);
         assert_eq!(ecs.get_defenses(&other).health, starting_health);
-    }
-
-    #[test]
-    fn knockback() {
-        let mut ecs = create_test_state().with_player(2, 2, 100).with_character(2, 3, 0).with_map().build();
-        let player = find_at(&mut ecs, 2, 2);
-        let target = find_at(&mut ecs, 2, 3);
-        begin_bolt(
-            &mut ecs,
-            &player,
-            Point::init(2, 3),
-            Damage::init(1).with_option(DamageOptions::KNOCKBACK),
-            BoltKind::Fire,
-        );
-        wait_for_animations(&mut ecs);
-        assert_position(&ecs, &target, Point::init(2, 4));
-    }
-
-    #[test]
-    fn knockback_against_a_wall() {
-        let mut ecs = create_test_state().with_player(2, 1, 100).with_character(2, 0, 0).with_map().build();
-        let player = find_at(&mut ecs, 2, 1);
-        let target = find_at(&mut ecs, 2, 0);
-        begin_bolt(
-            &mut ecs,
-            &player,
-            Point::init(2, 0),
-            Damage::init(1).with_option(DamageOptions::KNOCKBACK),
-            BoltKind::Fire,
-        );
-        wait_for_animations(&mut ecs);
-        assert_position(&ecs, &target, Point::init(2, 0));
-    }
-
-    #[test]
-    fn knockback_against_another() {
-        let mut ecs = create_test_state()
-            .with_player(2, 2, 100)
-            .with_character(2, 3, 0)
-            .with_character(2, 4, 0)
-            .with_map()
-            .build();
-        let player = find_at(&mut ecs, 2, 2);
-        let target = find_at(&mut ecs, 2, 3);
-        begin_bolt(
-            &mut ecs,
-            &player,
-            Point::init(2, 3),
-            Damage::init(1).with_option(DamageOptions::KNOCKBACK),
-            BoltKind::Fire,
-        );
-        wait_for_animations(&mut ecs);
-        assert_position(&ecs, &target, Point::init(2, 3));
-    }
-
-    #[test]
-    fn add_charge_on_hit() {
-        let mut ecs = create_test_state().with_player(2, 2, 100).with_character(2, 3, 0).with_map().build();
-        let player = find_at(&mut ecs, 2, 2);
-        let target = find_at(&mut ecs, 2, 3);
-
-        begin_bolt(
-            &mut ecs,
-            &player,
-            Point::init(2, 3),
-            Damage::init(1).with_option(DamageOptions::ADD_CHARGE_STATUS),
-            BoltKind::Fire,
-        );
-        wait_for_animations(&mut ecs);
-
-        assert!(ecs.has_status(&target, StatusKind::StaticCharge));
-        assert_eq!(1, ecs.read_resource::<LogComponent>().log.contains_count("crackles with static electricity"));
-    }
-
-    #[test]
-    fn consumes_charge_for_damage() {
-        let mut ecs = create_test_state().with_player(2, 2, 100).with_character(2, 3, 0).with_map().build();
-        let player = find_at(&mut ecs, 2, 2);
-        let target = find_at(&mut ecs, 2, 3);
-
-        ecs.write_storage::<StatusComponent>()
-            .grab_mut(target)
-            .status
-            .add_status(StatusKind::StaticCharge, 100);
-
-        begin_bolt(
-            &mut ecs,
-            &player,
-            Point::init(2, 3),
-            Damage::init(0).with_option(DamageOptions::CONSUMES_CHARGE),
-            BoltKind::Fire,
-        );
-        wait_for_animations(&mut ecs);
-
-        assert_eq!(false, ecs.has_status(&target, StatusKind::StaticCharge));
-        assert_ne!(ecs.get_defenses(&target).max_health, ecs.get_defenses(&target).health);
-    }
-
-    #[test]
-    fn consumes_no_status_for_no_damage() {
-        let mut ecs = create_test_state().with_player(2, 2, 100).with_character(2, 3, 0).with_map().build();
-        let player = find_at(&mut ecs, 2, 2);
-        let target = find_at(&mut ecs, 2, 3);
-
-        begin_bolt(
-            &mut ecs,
-            &player,
-            Point::init(2, 3),
-            Damage::init(0).with_option(DamageOptions::CONSUMES_CHARGE),
-            BoltKind::Fire,
-        );
-        wait_for_animations(&mut ecs);
-
-        assert_eq!(false, ecs.has_status(&target, StatusKind::StaticCharge));
-        assert_eq!(ecs.get_defenses(&target).max_health, ecs.get_defenses(&target).health);
     }
 }

--- a/src/clash/content/gunslinger.rs
+++ b/src/clash/content/gunslinger.rs
@@ -87,7 +87,8 @@ pub fn gunslinger_skills(m: &mut HashMap<&'static str, SkillInfo>) {
             Some(AIMED_SHOT_BASE_RANGE - 2),
             true,
         )
-        .with_ammo(AmmoKind::Bullets, 1),
+        .with_ammo(AmmoKind::Bullets, 1)
+        .with_focus_use(0.5),
     );
 
     m.insert(
@@ -104,7 +105,8 @@ pub fn gunslinger_skills(m: &mut HashMap<&'static str, SkillInfo>) {
             Some(AIMED_SHOT_BASE_RANGE),
             true,
         )
-        .with_ammo(AmmoKind::Bullets, 1),
+        .with_ammo(AmmoKind::Bullets, 1)
+        .with_focus_use(0.5),
     );
 
     m.insert(
@@ -119,7 +121,8 @@ pub fn gunslinger_skills(m: &mut HashMap<&'static str, SkillInfo>) {
             Some(AIMED_SHOT_BASE_RANGE + 2),
             true,
         )
-        .with_ammo(AmmoKind::Bullets, 1),
+        .with_ammo(AmmoKind::Bullets, 1)
+        .with_focus_use(0.5),
     );
 
     m.insert("Swap Ammo Kind", SkillInfo::init(Some("b_28.png"), TargetType::None, SkillEffect::RotateAmmo()));

--- a/src/clash/content/gunslinger.rs
+++ b/src/clash/content/gunslinger.rs
@@ -13,9 +13,9 @@ pub fn setup_gunslinger(ecs: &mut World, invoker: &Entity) {
 
 fn get_weapon_skills(ammo: TargetAmmo) -> Vec<&'static str> {
     match ammo {
-        TargetAmmo::Magnum => vec!["Aimed Shot", "Swap Ammo Kind"],
-        TargetAmmo::Ignite => vec!["Explosive Blast", "Swap Ammo Kind"],
-        TargetAmmo::Cyclone => vec!["Air Lance", "Swap Ammo Kind"],
+        TargetAmmo::Magnum => vec!["Aimed Shot", "Triple Shot", "Swap Ammo"],
+        TargetAmmo::Ignite => vec!["Explosive Blast", "Dragon's Breath", "Swap Ammo"],
+        TargetAmmo::Cyclone => vec!["Air Lance", "Tornado Shot", "Swap Ammo"],
     }
 }
 
@@ -81,14 +81,15 @@ pub fn gunslinger_skills(m: &mut HashMap<&'static str, SkillInfo>) {
     m.insert(
         "Aimed Shot",
         SkillInfo::init_with_distance(
-            Some("SpellBook01_63.png"),
+            Some("gun_06_b.PNG"),
             TargetType::Enemy,
             SkillEffect::RangedAttack(Damage::init(AIMED_SHOT_BASE_STRENGTH + 2), BoltKind::Bullet),
             Some(AIMED_SHOT_BASE_RANGE - 2),
             true,
         )
         .with_ammo(AmmoKind::Bullets, 1)
-        .with_focus_use(0.5),
+        .with_focus_use(0.5)
+        .with_alternate("Reload"),
     );
 
     m.insert(
@@ -106,7 +107,8 @@ pub fn gunslinger_skills(m: &mut HashMap<&'static str, SkillInfo>) {
             true,
         )
         .with_ammo(AmmoKind::Bullets, 1)
-        .with_focus_use(0.5),
+        .with_focus_use(0.5)
+        .with_alternate("Reload"),
     );
 
     m.insert(
@@ -122,10 +124,70 @@ pub fn gunslinger_skills(m: &mut HashMap<&'static str, SkillInfo>) {
             true,
         )
         .with_ammo(AmmoKind::Bullets, 1)
-        .with_focus_use(0.5),
+        .with_focus_use(0.5)
+        .with_alternate("Reload"),
     );
 
-    m.insert("Swap Ammo Kind", SkillInfo::init(Some("b_28.png"), TargetType::None, SkillEffect::RotateAmmo()));
+    const TRIPLE_SHOT_BASE_RANGE: u32 = 4;
+    const TRIPLE_SHOT_BASE_STRENGTH: u32 = 3;
+
+    m.insert(
+        "Triple Shot",
+        SkillInfo::init_with_distance(
+            Some("SpellBook06_22.png"),
+            TargetType::Enemy,
+            SkillEffect::RangedAttack(
+                Damage::init(TRIPLE_SHOT_BASE_STRENGTH).with_option(DamageOptions::TRIPLE_SHOT),
+                BoltKind::Bullet,
+            ),
+            Some(TRIPLE_SHOT_BASE_RANGE),
+            true,
+        )
+        .with_ammo(AmmoKind::Bullets, 3)
+        .with_alternate("Reload"),
+    );
+
+    m.insert(
+        "Dragon's Breath",
+        SkillInfo::init_with_distance(
+            Some("r_16.png"),
+            TargetType::Enemy,
+            SkillEffect::RangedAttack(
+                Damage::init(TRIPLE_SHOT_BASE_STRENGTH)
+                    .with_option(DamageOptions::TRIPLE_SHOT)
+                    .with_option(DamageOptions::RAISE_TEMPERATURE),
+                BoltKind::FireBullet,
+            ),
+            Some(TRIPLE_SHOT_BASE_RANGE - 1),
+            true,
+        )
+        .with_ammo(AmmoKind::Bullets, 3)
+        .with_alternate("Reload"),
+    );
+
+    m.insert(
+        "Tornado Shot",
+        SkillInfo::init_with_distance(
+            Some("SpellBookPage09_66.png"),
+            TargetType::Enemy,
+            SkillEffect::RangedAttack(
+                Damage::init(TRIPLE_SHOT_BASE_RANGE)
+                    .with_option(DamageOptions::TRIPLE_SHOT)
+                    .with_option(DamageOptions::CONSUMES_CHARGE),
+                BoltKind::AirBullet,
+            ),
+            Some(TRIPLE_SHOT_BASE_RANGE),
+            true,
+        )
+        .with_ammo(AmmoKind::Bullets, 3)
+        .with_alternate("Reload"),
+    );
+
+    m.insert(
+        "Reload",
+        SkillInfo::init(Some("b_45.png"), TargetType::None, SkillEffect::Reload(AmmoKind::Bullets)),
+    );
+    m.insert("Swap Ammo", SkillInfo::init(Some("b_28.png"), TargetType::None, SkillEffect::RotateAmmo()));
 }
 
 #[cfg(test)]
@@ -140,7 +202,7 @@ mod tests {
         setup_gunslinger(&mut ecs, &player);
 
         assert!(ecs.has_status(&player, StatusKind::Magnum));
-        assert_eq!(2, ecs.read_storage::<SkillsComponent>().grab(player).skills.len());
+        assert_eq!(3, ecs.read_storage::<SkillsComponent>().grab(player).skills.len());
     }
 
     #[test]

--- a/src/clash/content/gunslinger.rs
+++ b/src/clash/content/gunslinger.rs
@@ -137,7 +137,7 @@ pub fn gunslinger_skills(m: &mut HashMap<&'static str, SkillInfo>) {
             Some("SpellBook06_22.png"),
             TargetType::Enemy,
             SkillEffect::RangedAttack(
-                Damage::init(TRIPLE_SHOT_BASE_STRENGTH).with_option(DamageOptions::TRIPLE_SHOT),
+                Damage::init(TRIPLE_SHOT_BASE_STRENGTH + 1).with_option(DamageOptions::TRIPLE_SHOT),
                 BoltKind::Bullet,
             ),
             Some(TRIPLE_SHOT_BASE_RANGE),
@@ -158,7 +158,7 @@ pub fn gunslinger_skills(m: &mut HashMap<&'static str, SkillInfo>) {
                     .with_option(DamageOptions::RAISE_TEMPERATURE),
                 BoltKind::FireBullet,
             ),
-            Some(TRIPLE_SHOT_BASE_RANGE - 1),
+            Some(TRIPLE_SHOT_BASE_RANGE + 1),
             true,
         )
         .with_ammo(AmmoKind::Bullets, 3)
@@ -176,7 +176,7 @@ pub fn gunslinger_skills(m: &mut HashMap<&'static str, SkillInfo>) {
                     .with_option(DamageOptions::CONSUMES_CHARGE),
                 BoltKind::AirBullet,
             ),
-            Some(TRIPLE_SHOT_BASE_RANGE),
+            Some(TRIPLE_SHOT_BASE_RANGE + 2),
             true,
         )
         .with_ammo(AmmoKind::Bullets, 3)

--- a/src/clash/content/test.rs
+++ b/src/clash/content/test.rs
@@ -38,6 +38,10 @@ pub fn add_test_skills(m: &mut HashMap<&'static str, SkillInfo>) {
         "TestAmmo",
         SkillInfo::init(None, TargetType::None, SkillEffect::None).with_ammo(AmmoKind::Bullets, 1),
     );
+    m.insert(
+        "TestMultiAmmo",
+        SkillInfo::init(None, TargetType::None, SkillEffect::None).with_ammo(AmmoKind::Bullets, 3),
+    );
     m.insert("TestReload", SkillInfo::init(None, TargetType::None, SkillEffect::Reload(AmmoKind::Bullets)));
     m.insert(
         "TestExhaustion",

--- a/src/clash/damage.rs
+++ b/src/clash/damage.rs
@@ -1,6 +1,9 @@
 use serde::{Deserialize, Serialize};
+use specs::prelude::*;
 
-use super::Strength;
+use super::*;
+use crate::atlas::{EasyMutECS, Point};
+use crate::clash::{Direction, EventCoordinator};
 
 bitflags! {
     #[derive(Serialize, Deserialize)]
@@ -12,6 +15,7 @@ bitflags! {
         const ADD_CHARGE_STATUS =       0b00010000;
         const CONSUMES_CHARGE   =       0b00100000;
         const PIERCE_DEFENSES   =       0b01000000;
+        const TRIPLE_SHOT       =       0b10000000;
     }
 }
 
@@ -52,5 +56,234 @@ impl RolledDamage {
             amount,
             options: initial_damage.options,
         }
+    }
+}
+
+pub fn apply_damage_to_location(ecs: &mut World, target_position: Point, source_position: Option<Point>, damage: Damage) {
+    if let Some(target) = find_character_at_location(ecs, target_position) {
+        apply_damage_to_character(ecs, damage, &target, source_position);
+    }
+}
+
+pub fn apply_damage_to_character(ecs: &mut World, damage: Damage, target: &Entity, source_position: Option<Point>) {
+    let damage_count = {
+        if damage.options.contains(DamageOptions::TRIPLE_SHOT) {
+            3
+        } else {
+            1
+        }
+    };
+    for _ in 0..damage_count {
+        apply_damage_core(ecs, damage, target, source_position);
+    }
+}
+
+fn apply_damage_core(ecs: &mut World, damage: Damage, target: &Entity, source_position: Option<Point>) {
+    let rolled_damage = {
+        let mut character_infos = ecs.write_storage::<CharacterInfoComponent>();
+        let defenses = &mut character_infos.grab_mut(*target).character.defenses;
+        defenses.apply_damage(damage, &mut ecs.fetch_mut::<RandomComponent>().rand)
+    };
+    ecs.log(format!(
+        "{} took {} damage (Str {}).",
+        ecs.get_name(&target).unwrap().as_str(),
+        rolled_damage.amount,
+        damage.dice()
+    ));
+
+    if rolled_damage.options.contains(DamageOptions::KNOCKBACK) {
+        if let Some(source_position) = source_position {
+            let current_position = ecs.get_position(target);
+            let direction_of_impact = Direction::from_two_points(&source_position, &current_position.origin);
+            if let Some(new_origin) = direction_of_impact.point_in_direction(&current_position.origin) {
+                let new_position = current_position.move_to(new_origin);
+                if is_area_clear(ecs, &new_position.all_positions(), target) {
+                    begin_move(ecs, target, new_position, PostMoveAction::None);
+                }
+            }
+        }
+    }
+    if rolled_damage.options.contains(DamageOptions::ADD_CHARGE_STATUS) {
+        ecs.log(format!("{} crackles with static electricity", ecs.get_name(target).unwrap()));
+        ecs.write_storage::<StatusComponent>()
+            .grab_mut(*target)
+            .status
+            .add_status(StatusKind::StaticCharge, 300);
+    }
+    if rolled_damage.options.contains(DamageOptions::CONSUMES_CHARGE) && ecs.has_status(target, StatusKind::StaticCharge) {
+        const STATIC_CHARGE_DAMAGE: u32 = 4;
+        apply_damage_to_character(
+            ecs,
+            Damage::init(STATIC_CHARGE_DAMAGE).with_option(DamageOptions::PIERCE_DEFENSES),
+            target,
+            None,
+        );
+        ecs.write_storage::<StatusComponent>()
+            .grab_mut(*target)
+            .status
+            .remove_status(StatusKind::StaticCharge);
+    }
+
+    ecs.raise_event(EventKind::Damage(rolled_damage), Some(*target));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::atlas::EasyMutECS;
+
+    #[test]
+    fn knockback() {
+        let mut ecs = create_test_state().with_player(2, 2, 100).with_character(2, 3, 0).with_map().build();
+        let player = find_at(&mut ecs, 2, 2);
+        let target = find_at(&mut ecs, 2, 3);
+        begin_bolt(
+            &mut ecs,
+            &player,
+            Point::init(2, 3),
+            Damage::init(1).with_option(DamageOptions::KNOCKBACK),
+            BoltKind::Fire,
+        );
+        wait_for_animations(&mut ecs);
+        assert_position(&ecs, &target, Point::init(2, 4));
+    }
+
+    #[test]
+    fn knockback_against_a_wall() {
+        let mut ecs = create_test_state().with_player(2, 1, 100).with_character(2, 0, 0).with_map().build();
+        let player = find_at(&mut ecs, 2, 1);
+        let target = find_at(&mut ecs, 2, 0);
+        begin_bolt(
+            &mut ecs,
+            &player,
+            Point::init(2, 0),
+            Damage::init(1).with_option(DamageOptions::KNOCKBACK),
+            BoltKind::Fire,
+        );
+        wait_for_animations(&mut ecs);
+        assert_position(&ecs, &target, Point::init(2, 0));
+    }
+
+    #[test]
+    fn knockback_against_another() {
+        let mut ecs = create_test_state()
+            .with_player(2, 2, 100)
+            .with_character(2, 3, 0)
+            .with_character(2, 4, 0)
+            .with_map()
+            .build();
+        let player = find_at(&mut ecs, 2, 2);
+        let target = find_at(&mut ecs, 2, 3);
+        begin_bolt(
+            &mut ecs,
+            &player,
+            Point::init(2, 3),
+            Damage::init(1).with_option(DamageOptions::KNOCKBACK),
+            BoltKind::Fire,
+        );
+        wait_for_animations(&mut ecs);
+        assert_position(&ecs, &target, Point::init(2, 3));
+    }
+
+    #[test]
+    fn add_charge_on_hit() {
+        let mut ecs = create_test_state().with_player(2, 2, 100).with_character(2, 3, 0).with_map().build();
+        let player = find_at(&mut ecs, 2, 2);
+        let target = find_at(&mut ecs, 2, 3);
+
+        begin_bolt(
+            &mut ecs,
+            &player,
+            Point::init(2, 3),
+            Damage::init(1).with_option(DamageOptions::ADD_CHARGE_STATUS),
+            BoltKind::Fire,
+        );
+        wait_for_animations(&mut ecs);
+
+        assert!(ecs.has_status(&target, StatusKind::StaticCharge));
+        assert_eq!(1, ecs.read_resource::<LogComponent>().log.contains_count("crackles with static electricity"));
+    }
+
+    #[test]
+    fn consumes_charge_for_damage() {
+        let mut ecs = create_test_state().with_player(2, 2, 100).with_character(2, 3, 0).with_map().build();
+        let player = find_at(&mut ecs, 2, 2);
+        let target = find_at(&mut ecs, 2, 3);
+
+        ecs.write_storage::<StatusComponent>()
+            .grab_mut(target)
+            .status
+            .add_status(StatusKind::StaticCharge, 100);
+
+        begin_bolt(
+            &mut ecs,
+            &player,
+            Point::init(2, 3),
+            Damage::init(0).with_option(DamageOptions::CONSUMES_CHARGE),
+            BoltKind::Fire,
+        );
+        wait_for_animations(&mut ecs);
+
+        assert_eq!(false, ecs.has_status(&target, StatusKind::StaticCharge));
+        let health = &ecs.get_defenses(&target);
+        assert_ne!(health.max_health, health.health);
+    }
+
+    #[test]
+    fn consumes_no_status_for_no_damage() {
+        let mut ecs = create_test_state().with_player(2, 2, 100).with_character(2, 3, 0).with_map().build();
+        let player = find_at(&mut ecs, 2, 2);
+        let target = find_at(&mut ecs, 2, 3);
+
+        begin_bolt(
+            &mut ecs,
+            &player,
+            Point::init(2, 3),
+            Damage::init(0).with_option(DamageOptions::CONSUMES_CHARGE),
+            BoltKind::Fire,
+        );
+        wait_for_animations(&mut ecs);
+
+        assert_eq!(false, ecs.has_status(&target, StatusKind::StaticCharge));
+
+        let health = &ecs.get_defenses(&target);
+        assert_eq!(health.max_health, health.health);
+    }
+
+    #[test]
+    fn triple_shot_applies_three_time() {
+        let mut ecs = create_test_state().with_player(2, 2, 100).with_character(2, 3, 0).with_map().build();
+        let player = find_at(&mut ecs, 2, 2);
+
+        begin_bolt(
+            &mut ecs,
+            &player,
+            Point::init(2, 3),
+            Damage::init(3).with_option(DamageOptions::TRIPLE_SHOT),
+            BoltKind::Fire,
+        );
+        wait_for_animations(&mut ecs);
+        assert_eq!(3, ecs.read_resource::<LogComponent>().log.contains_count("took"));
+    }
+
+    #[test]
+    fn triple_shot_applies_armor_each_time() {
+        let mut ecs = create_test_state().with_player(2, 2, 100).with_character(2, 3, 0).with_map().build();
+        let player = find_at(&mut ecs, 2, 2);
+        let target = find_at(&mut ecs, 2, 3);
+
+        ecs.write_storage::<CharacterInfoComponent>().grab_mut(target).character.defenses.armor = 6;
+
+        begin_bolt(
+            &mut ecs,
+            &player,
+            Point::init(2, 3),
+            Damage::init(3).with_option(DamageOptions::TRIPLE_SHOT),
+            BoltKind::Fire,
+        );
+        wait_for_animations(&mut ecs);
+
+        let health = &ecs.get_defenses(&target);
+        assert_eq!(health.max_health, health.health);
     }
 }

--- a/src/clash/skills.rs
+++ b/src/clash/skills.rs
@@ -324,7 +324,7 @@ fn spend_ammo(ecs: &mut World, invoker: &Entity, skill: &SkillInfo) {
         Some(ammo_info) => {
             let kind = ammo_info.kind;
             let current_ammo = { ecs.read_storage::<SkillResourceComponent>().grab(*invoker).ammo[&kind] };
-            set_ammo(ecs, invoker, kind, current_ammo - 1);
+            set_ammo(ecs, invoker, kind, current_ammo - ammo_info.usage);
         }
         None => {}
     }
@@ -584,6 +584,16 @@ mod tests {
         }
 
         assert_eq!(false, can_invoke_skill(&mut ecs, &player, &skill, None));
+    }
+
+    #[test]
+    fn skills_with_multiple_ammo() {
+        let mut ecs = create_test_state().with_character(2, 2, 100).with_map().build();
+        let player = find_at(&ecs, 2, 2);
+        add_bullets(&mut ecs, &player, 6);
+
+        invoke_skill(&mut ecs, &player, "TestMultiAmmo", None);
+        assert_eq!(1, get_skill("TestMultiAmmo").get_remaining_usages(&ecs, &player).unwrap());
     }
 
     #[test]

--- a/src/clash/skills.rs
+++ b/src/clash/skills.rs
@@ -177,12 +177,25 @@ impl SkillInfo {
         usages.iter().filter_map(|x| *x).min()
     }
 
-    pub fn is_usable(&self, ecs: &World, entity: &Entity) -> bool {
-        match self.get_remaining_usages(ecs, entity) {
-            Some(amount) => amount > 0,
-            None => true,
+    pub fn is_usable(&self, ecs: &World, entity: &Entity) -> UsableResults {
+        if self.get_focus_usage(ecs, entity).unwrap_or(1) == 0 {
+            return UsableResults::LacksFocus;
         }
+        if self.get_exhaustion_usage(ecs, entity).unwrap_or(1) == 0 {
+            return UsableResults::Exhaustion;
+        }
+        if self.get_ammo_usage(ecs, entity).unwrap_or(1) == 0 {
+            return UsableResults::LacksAmmo;
+        }
+        UsableResults::Usable
     }
+}
+
+pub enum UsableResults {
+    Usable,
+    LacksAmmo,
+    Exhaustion,
+    LacksFocus,
 }
 
 lazy_static! {


### PR DESCRIPTION
- Add second gunslinger skill, which fires a triple shot (one for each ammo variant).
- Add focus use to aimed skills
- Clean up bullet animations to be more visible and correct on screen
- Fix multiple ammo skills to actually cost multiple ammo. :facepalm: 
- "Alternate" skills only proc/show on lack of ammo, not just not usable. A skill that needs focus and ammo shouldn't show reload if out of focus.