### PR TITLE
Show the utility of slingers of lead

### DIFF
--- a/src/arena/views/status_display.rs
+++ b/src/arena/views/status_display.rs
@@ -87,6 +87,7 @@ pub fn get_icon_name_for_status(kind: StatusKind) -> &'static str {
         StatusKind::Magnum => "b_30.png",
         StatusKind::StaticCharge => "SpellBook06_89.png",
         StatusKind::Aimed => "SpellBook08_83.png",
+        StatusKind::Armored => "SpellBook08_122.png",
         #[cfg(test)]
         _ => "",
     }
@@ -101,5 +102,6 @@ pub fn all_icon_filenames() -> &'static [&'static str] {
         "b_30.png",
         "SpellBook06_89.png",
         "SpellBook08_83.png",
+        "SpellBook08_122.png",
     ]
 }

--- a/src/clash/combat.rs
+++ b/src/clash/combat.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use specs::prelude::*;
 
 use super::*;
-use crate::atlas::{EasyECS, EasyMutECS, EasyMutWorld, Point, SizedPoint};
+use crate::atlas::{EasyECS, EasyMutWorld, Point, SizedPoint};
 use crate::clash::{EventCoordinator, FieldComponent};
 
 #[derive(Clone, Copy, Deserialize, Serialize)]
@@ -96,7 +96,7 @@ pub fn begin_bolt_nearest_in_range(ecs: &mut World, source: &Entity, range: Opti
 
 pub fn begin_bolt(ecs: &mut World, source: &Entity, target_position: Point, mut strength: Damage, kind: BoltKind) {
     if ecs.has_status(source, StatusKind::Aimed) {
-        ecs.write_storage::<StatusComponent>().grab_mut(*source).status.remove_status(StatusKind::Aimed);
+        ecs.remove_status(source, StatusKind::Aimed);
         strength = strength.copy_more_strength(2);
     }
 

--- a/src/clash/components.rs
+++ b/src/clash/components.rs
@@ -10,7 +10,7 @@ use specs_derive::*;
 
 use super::EventCoordinator;
 use super::Log;
-use crate::atlas::{EasyECS, Point, SizedPoint, ToSerialize};
+use crate::atlas::{EasyECS, EasyMutECS, Point, SizedPoint, ToSerialize};
 use crate::clash::{AmmoKind, AttackInfo, BehaviorKind, CharacterInfo, Defenses, Map, StatusKind, StatusStore, Temperature};
 
 #[derive(Hash, PartialEq, Eq, Component, ConvertSaveload, Clone)]
@@ -275,6 +275,23 @@ pub trait Framer {
 impl Framer for World {
     fn get_current_frame(&self) -> u64 {
         self.read_resource::<FrameComponent>().current_frame
+    }
+}
+
+pub trait StatusApplier {
+    fn add_status(&self, entity: &Entity, kind: StatusKind, length: i32);
+    fn remove_status(&self, entity: &Entity, kind: StatusKind);
+    fn add_trait(&mut self, entity: &Entity, kind: StatusKind);
+}
+impl StatusApplier for World {
+    fn add_status(&self, entity: &Entity, kind: StatusKind, length: i32) {
+        self.write_storage::<StatusComponent>().grab_mut(*entity).status.add_status(kind, length);
+    }
+    fn remove_status(&self, entity: &Entity, kind: StatusKind) {
+        self.write_storage::<StatusComponent>().grab_mut(*entity).status.remove_status(kind);
+    }
+    fn add_trait(&mut self, entity: &Entity, kind: StatusKind) {
+        self.write_storage::<StatusComponent>().grab_mut(*entity).status.add_trait(kind);
     }
 }
 

--- a/src/clash/content/gunslinger.rs
+++ b/src/clash/content/gunslinger.rs
@@ -5,7 +5,10 @@ use super::super::*;
 use crate::atlas::{EasyMutECS, EasyMutWorld};
 
 pub fn setup_gunslinger(ecs: &mut World, invoker: &Entity) {
-    ecs.shovel(*invoker, SkillResourceComponent::init(&[(AmmoKind::Bullets, 6)]).with_focus(1.0));
+    ecs.shovel(
+        *invoker,
+        SkillResourceComponent::init(&[(AmmoKind::Bullets, 6, 6), (AmmoKind::Adrenaline, 0, 100)]).with_focus(1.0),
+    );
 
     add_skills_to_front(ecs, invoker, &get_weapon_skills(TargetAmmo::Magnum));
     set_weapon_trait(ecs, invoker, TargetAmmo::Magnum);

--- a/src/clash/content/gunslinger.rs
+++ b/src/clash/content/gunslinger.rs
@@ -78,30 +78,42 @@ pub fn rotate_ammo(ecs: &mut World, invoker: &Entity) {
 }
 
 pub fn gunslinger_skills(m: &mut HashMap<&'static str, SkillInfo>) {
+    add_aimed_skills(m);
+    add_triple_shot_skills(m);
+    add_move_and_shoot_skills(m);
+
+    m.insert(
+        "Reload",
+        SkillInfo::init(Some("b_45.png"), TargetType::None, SkillEffect::Reload(AmmoKind::Bullets)),
+    );
+    m.insert("Swap Ammo", SkillInfo::init(Some("b_28.png"), TargetType::None, SkillEffect::RotateAmmo()));
+}
+
+fn add_aimed_skills(m: &mut HashMap<&'static str, SkillInfo>) {
     const AIMED_SHOT_BASE_RANGE: u32 = 7;
     const AIMED_SHOT_BASE_STRENGTH: u32 = 5;
 
     m.insert(
         "Aimed Shot",
         SkillInfo::init_with_distance(
-            Some("gun_06_b.PNG"),
+            Some("gun_05_b.PNG"),
             TargetType::Enemy,
             SkillEffect::RangedAttack(
-                Damage::init(AIMED_SHOT_BASE_STRENGTH + 1).with_option(DamageOptions::AIMED_SHOT),
+                Damage::init(AIMED_SHOT_BASE_STRENGTH + 0).with_option(DamageOptions::AIMED_SHOT),
                 BoltKind::Bullet,
             ),
-            Some(AIMED_SHOT_BASE_RANGE - 1),
+            Some(AIMED_SHOT_BASE_RANGE - 0),
             true,
         )
-        .with_ammo(AmmoKind::Bullets, 1)
-        .with_focus_use(0.5)
+        .with_ammo(AmmoKind::Bullets, 0)
+        .with_focus_use(-1.5)
         .with_alternate("Reload"),
     );
 
     m.insert(
         "Explosive Blast",
         SkillInfo::init_with_distance(
-            Some("SpellBook01_37.png"),
+            Some("SpellBook00_37.png"),
             TargetType::Enemy,
             SkillEffect::RangedAttack(
                 Damage::init(AIMED_SHOT_BASE_STRENGTH)
@@ -112,28 +124,30 @@ pub fn gunslinger_skills(m: &mut HashMap<&'static str, SkillInfo>) {
             Some(AIMED_SHOT_BASE_RANGE),
             true,
         )
-        .with_ammo(AmmoKind::Bullets, 1)
-        .with_focus_use(0.5)
+        .with_ammo(AmmoKind::Bullets, 0)
+        .with_focus_use(-1.5)
         .with_alternate("Reload"),
     );
 
     m.insert(
         "Air Lance",
         SkillInfo::init_with_distance(
-            Some("SpellBook06_46.png"),
+            Some("SpellBook05_46.png"),
             TargetType::Enemy,
             SkillEffect::RangedAttack(
-                Damage::init(AIMED_SHOT_BASE_STRENGTH - 1).with_option(DamageOptions::CONSUMES_CHARGE_KNOCKBACK),
+                Damage::init(AIMED_SHOT_BASE_STRENGTH - 0).with_option(DamageOptions::CONSUMES_CHARGE_KNOCKBACK),
                 BoltKind::AirBullet,
             ),
-            Some(AIMED_SHOT_BASE_RANGE + 2),
+            Some(AIMED_SHOT_BASE_RANGE + 1),
             true,
         )
-        .with_ammo(AmmoKind::Bullets, 1)
-        .with_focus_use(0.5)
+        .with_ammo(AmmoKind::Bullets, 0)
+        .with_focus_use(-1.5)
         .with_alternate("Reload"),
     );
+}
 
+fn add_triple_shot_skills(m: &mut HashMap<&'static str, SkillInfo>) {
     const TRIPLE_SHOT_BASE_RANGE: u32 = 5;
     const TRIPLE_SHOT_BASE_STRENGTH: u32 = 3;
 
@@ -188,7 +202,9 @@ pub fn gunslinger_skills(m: &mut HashMap<&'static str, SkillInfo>) {
         .with_ammo(AmmoKind::Bullets, 3)
         .with_alternate("Reload"),
     );
+}
 
+fn add_move_and_shoot_skills(m: &mut HashMap<&'static str, SkillInfo>) {
     const MOVE_AND_SHOOT_BASE_RANGE: u32 = 5;
     const MOVE_AND_SHOOT_BASE_STRENGTH: u32 = 3;
     m.insert(
@@ -244,12 +260,6 @@ pub fn gunslinger_skills(m: &mut HashMap<&'static str, SkillInfo>) {
         .with_exhaustion(25.0)
         .with_alternate("Reload"),
     );
-
-    m.insert(
-        "Reload",
-        SkillInfo::init(Some("b_45.png"), TargetType::None, SkillEffect::Reload(AmmoKind::Bullets)),
-    );
-    m.insert("Swap Ammo", SkillInfo::init(Some("b_28.png"), TargetType::None, SkillEffect::RotateAmmo()));
 }
 
 #[cfg(test)]

--- a/src/clash/content/gunslinger.rs
+++ b/src/clash/content/gunslinger.rs
@@ -16,7 +16,7 @@ pub fn setup_gunslinger(ecs: &mut World, invoker: &Entity) {
 
 fn get_weapon_skills(ammo: TargetAmmo) -> Vec<&'static str> {
     match ammo {
-        TargetAmmo::Magnum => vec!["Aimed Shot", "Triple Shot", "Quick Shot", "Trick Shot", "Swap Ammo"],
+        TargetAmmo::Magnum => vec!["Aimed Shot", "Triple Shot", "Quick Shot", "Blink Shot", "Swap Ammo"],
         TargetAmmo::Ignite => vec!["Explosive Blast", "Dragon's Breath", "Hot Hands", "Showdown", "Swap Ammo"],
         TargetAmmo::Cyclone => vec!["Air Lance", "Tornado Shot", "Lightning Speed", "Dive", "Swap Ammo"],
     }
@@ -265,15 +265,32 @@ fn add_move_and_shoot_skills(m: &mut HashMap<&'static str, SkillInfo>) {
 
 fn add_utility_skills(m: &mut HashMap<&'static str, SkillInfo>) {
     m.insert(
-        "Trick Shot",
-        SkillInfo::init_with_distance(Some("SpellBook06_118.png"), TargetType::Enemy, SkillEffect::Move, Some(7), true).with_ammo(AmmoKind::Adrenaline, 50),
+        "Blink Shot",
+        SkillInfo::init_with_distance(
+            Some("SpellBook06_118.png"),
+            TargetType::Enemy,
+            SkillEffect::ThenBuff(Box::from(SkillEffect::RangedAttack(Damage::init(5), BoltKind::Bullet)), StatusKind::Aimed, 300),
+            Some(7),
+            true,
+        )
+        .with_no_time()
+        .with_ammo(AmmoKind::Adrenaline, 50)
+        .with_ammo(AmmoKind::Bullets, 1),
     );
     m.insert(
         "Showdown",
         SkillInfo::init_with_distance(
             Some("SpellBook03_54.png"),
             TargetType::None,
-            SkillEffect::BuffThen(StatusKind::Armored, 300, Box::from(SkillEffect::Reload(AmmoKind::Bullets))),
+            SkillEffect::BuffThen(
+                StatusKind::Aimed,
+                300,
+                Box::from(SkillEffect::BuffThen(
+                    StatusKind::Armored,
+                    300,
+                    Box::from(SkillEffect::Reload(AmmoKind::Bullets)),
+                )),
+            ),
             Some(3),
             true,
         )
@@ -281,7 +298,14 @@ fn add_utility_skills(m: &mut HashMap<&'static str, SkillInfo>) {
     );
     m.insert(
         "Dive",
-        SkillInfo::init_with_distance(Some("SpellBook08_121.png"), TargetType::Tile, SkillEffect::Move, Some(3), true).with_ammo(AmmoKind::Adrenaline, 50),
+        SkillInfo::init_with_distance(
+            Some("SpellBook08_121.png"),
+            TargetType::Tile,
+            SkillEffect::BuffThen(StatusKind::Armored, 300, Box::from(SkillEffect::Move)),
+            Some(3),
+            true,
+        )
+        .with_ammo(AmmoKind::Adrenaline, 50),
     );
 }
 

--- a/src/clash/content/gunslinger.rs
+++ b/src/clash/content/gunslinger.rs
@@ -274,8 +274,7 @@ fn add_utility_skills(m: &mut HashMap<&'static str, SkillInfo>) {
             true,
         )
         .with_no_time()
-        .with_ammo(AmmoKind::Adrenaline, 50)
-        .with_ammo(AmmoKind::Bullets, 1),
+        .with_ammo(AmmoKind::Adrenaline, 50),
     );
     m.insert(
         "Showdown",

--- a/src/clash/content/gunslinger.rs
+++ b/src/clash/content/gunslinger.rs
@@ -266,11 +266,18 @@ fn add_move_and_shoot_skills(m: &mut HashMap<&'static str, SkillInfo>) {
 fn add_utility_skills(m: &mut HashMap<&'static str, SkillInfo>) {
     m.insert(
         "Trick Shot",
-        SkillInfo::init_with_distance(Some("SpellBook06_118.png"), TargetType::Tile, SkillEffect::Move, Some(3), true).with_ammo(AmmoKind::Adrenaline, 50),
+        SkillInfo::init_with_distance(Some("SpellBook06_118.png"), TargetType::Enemy, SkillEffect::Move, Some(7), true).with_ammo(AmmoKind::Adrenaline, 50),
     );
     m.insert(
         "Showdown",
-        SkillInfo::init_with_distance(Some("SpellBook03_54.png"), TargetType::Tile, SkillEffect::Move, Some(3), true).with_ammo(AmmoKind::Adrenaline, 50),
+        SkillInfo::init_with_distance(
+            Some("SpellBook03_54.png"),
+            TargetType::None,
+            SkillEffect::BuffThen(StatusKind::Armored, 300, Box::from(SkillEffect::Reload(AmmoKind::Bullets))),
+            Some(3),
+            true,
+        )
+        .with_ammo(AmmoKind::Adrenaline, 50),
     );
     m.insert(
         "Dive",

--- a/src/clash/content/gunslinger.rs
+++ b/src/clash/content/gunslinger.rs
@@ -16,9 +16,9 @@ pub fn setup_gunslinger(ecs: &mut World, invoker: &Entity) {
 
 fn get_weapon_skills(ammo: TargetAmmo) -> Vec<&'static str> {
     match ammo {
-        TargetAmmo::Magnum => vec!["Aimed Shot", "Triple Shot", "Quick Shot", "Swap Ammo"],
-        TargetAmmo::Ignite => vec!["Explosive Blast", "Dragon's Breath", "Hot Hands", "Swap Ammo"],
-        TargetAmmo::Cyclone => vec!["Air Lance", "Tornado Shot", "Lightning Speed", "Swap Ammo"],
+        TargetAmmo::Magnum => vec!["Aimed Shot", "Triple Shot", "Quick Shot", "Trick Shot", "Swap Ammo"],
+        TargetAmmo::Ignite => vec!["Explosive Blast", "Dragon's Breath", "Hot Hands", "Showdown", "Swap Ammo"],
+        TargetAmmo::Cyclone => vec!["Air Lance", "Tornado Shot", "Lightning Speed", "Dive", "Swap Ammo"],
     }
 }
 
@@ -81,6 +81,7 @@ pub fn gunslinger_skills(m: &mut HashMap<&'static str, SkillInfo>) {
     add_aimed_skills(m);
     add_triple_shot_skills(m);
     add_move_and_shoot_skills(m);
+    add_utility_skills(m);
 
     m.insert(
         "Reload",
@@ -96,24 +97,24 @@ fn add_aimed_skills(m: &mut HashMap<&'static str, SkillInfo>) {
     m.insert(
         "Aimed Shot",
         SkillInfo::init_with_distance(
-            Some("gun_05_b.PNG"),
+            Some("gun_06_b.PNG"),
             TargetType::Enemy,
             SkillEffect::RangedAttack(
-                Damage::init(AIMED_SHOT_BASE_STRENGTH + 0).with_option(DamageOptions::AIMED_SHOT),
+                Damage::init(AIMED_SHOT_BASE_STRENGTH + 1).with_option(DamageOptions::AIMED_SHOT),
                 BoltKind::Bullet,
             ),
-            Some(AIMED_SHOT_BASE_RANGE - 0),
+            Some(AIMED_SHOT_BASE_RANGE - 1),
             true,
         )
-        .with_ammo(AmmoKind::Bullets, 0)
-        .with_focus_use(-1.5)
+        .with_ammo(AmmoKind::Bullets, 1)
+        .with_focus_use(0.5)
         .with_alternate("Reload"),
     );
 
     m.insert(
         "Explosive Blast",
         SkillInfo::init_with_distance(
-            Some("SpellBook00_37.png"),
+            Some("SpellBook01_37.png"),
             TargetType::Enemy,
             SkillEffect::RangedAttack(
                 Damage::init(AIMED_SHOT_BASE_STRENGTH)
@@ -124,25 +125,25 @@ fn add_aimed_skills(m: &mut HashMap<&'static str, SkillInfo>) {
             Some(AIMED_SHOT_BASE_RANGE),
             true,
         )
-        .with_ammo(AmmoKind::Bullets, 0)
-        .with_focus_use(-1.5)
+        .with_ammo(AmmoKind::Bullets, 1)
+        .with_focus_use(0.5)
         .with_alternate("Reload"),
     );
 
     m.insert(
         "Air Lance",
         SkillInfo::init_with_distance(
-            Some("SpellBook05_46.png"),
+            Some("SpellBook06_46.png"),
             TargetType::Enemy,
             SkillEffect::RangedAttack(
-                Damage::init(AIMED_SHOT_BASE_STRENGTH - 0).with_option(DamageOptions::CONSUMES_CHARGE_KNOCKBACK),
+                Damage::init(AIMED_SHOT_BASE_STRENGTH - 1).with_option(DamageOptions::CONSUMES_CHARGE_KNOCKBACK),
                 BoltKind::AirBullet,
             ),
-            Some(AIMED_SHOT_BASE_RANGE + 1),
+            Some(AIMED_SHOT_BASE_RANGE + 2),
             true,
         )
-        .with_ammo(AmmoKind::Bullets, 0)
-        .with_focus_use(-1.5)
+        .with_ammo(AmmoKind::Bullets, 1)
+        .with_focus_use(0.5)
         .with_alternate("Reload"),
     );
 }
@@ -262,6 +263,21 @@ fn add_move_and_shoot_skills(m: &mut HashMap<&'static str, SkillInfo>) {
     );
 }
 
+fn add_utility_skills(m: &mut HashMap<&'static str, SkillInfo>) {
+    m.insert(
+        "Trick Shot",
+        SkillInfo::init_with_distance(Some("SpellBook06_118.png"), TargetType::Tile, SkillEffect::Move, Some(3), true).with_ammo(AmmoKind::Adrenaline, 50),
+    );
+    m.insert(
+        "Showdown",
+        SkillInfo::init_with_distance(Some("SpellBook03_54.png"), TargetType::Tile, SkillEffect::Move, Some(3), true).with_ammo(AmmoKind::Adrenaline, 50),
+    );
+    m.insert(
+        "Dive",
+        SkillInfo::init_with_distance(Some("SpellBook08_121.png"), TargetType::Tile, SkillEffect::Move, Some(3), true).with_ammo(AmmoKind::Adrenaline, 50),
+    );
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -274,7 +290,7 @@ mod tests {
         setup_gunslinger(&mut ecs, &player);
 
         assert!(ecs.has_status(&player, StatusKind::Magnum));
-        assert_eq!(4, ecs.read_storage::<SkillsComponent>().grab(player).skills.len());
+        assert_eq!(5, ecs.read_storage::<SkillsComponent>().grab(player).skills.len());
     }
 
     #[test]

--- a/src/clash/content/test.rs
+++ b/src/clash/content/test.rs
@@ -78,4 +78,16 @@ pub fn add_test_skills(m: &mut HashMap<&'static str, SkillInfo>) {
             true,
         ),
     );
+
+    m.insert(
+        "ShootThenBuff",
+        SkillInfo::init_with_distance(
+            None,
+            TargetType::Enemy,
+            SkillEffect::ThenBuff(Box::from(SkillEffect::RangedAttack(Damage::init(2), BoltKind::Fire)), StatusKind::Aimed, 200),
+            Some(1),
+            true,
+        ),
+    );
+    m.insert("TestNoTime", SkillInfo::init(None, TargetType::None, SkillEffect::None).with_no_time());
 }

--- a/src/clash/content/test.rs
+++ b/src/clash/content/test.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use super::super::{AmmoKind, BoltKind, Damage, FieldKind, SkillEffect, SkillInfo, TargetType, WeaponKind};
+use super::super::*;
 
 pub fn add_test_skills(m: &mut HashMap<&'static str, SkillInfo>) {
     m.insert("TestNone", SkillInfo::init(None, TargetType::None, SkillEffect::None));
@@ -64,6 +64,16 @@ pub fn add_test_skills(m: &mut HashMap<&'static str, SkillInfo>) {
             None,
             TargetType::Tile,
             SkillEffect::MoveAndShoot(Damage::init(1), Some(5), BoltKind::Fire),
+            Some(1),
+            true,
+        ),
+    );
+    m.insert(
+        "BuffAndMove",
+        SkillInfo::init_with_distance(
+            None,
+            TargetType::Tile,
+            SkillEffect::BuffThen(StatusKind::Aimed, 200, Box::from(SkillEffect::Move)),
             Some(1),
             true,
         ),

--- a/src/clash/damage.rs
+++ b/src/clash/damage.rs
@@ -91,7 +91,13 @@ fn apply_damage_core(ecs: &mut World, damage: Damage, target: &Entity, source_po
     let rolled_damage = {
         let mut character_infos = ecs.write_storage::<CharacterInfoComponent>();
         let defenses = &mut character_infos.grab_mut(*target).character.defenses;
-        defenses.apply_damage(damage, &mut ecs.fetch_mut::<RandomComponent>().rand)
+
+        if ecs.has_status(target, StatusKind::Armored) {
+            const ADDITIONAL_ARMOR: u32 = 3;
+            defenses.apply_damage_with_addditional_armor(damage, ADDITIONAL_ARMOR, &mut ecs.fetch_mut::<RandomComponent>().rand)
+        } else {
+            defenses.apply_damage(damage, &mut ecs.fetch_mut::<RandomComponent>().rand)
+        }
     };
     ecs.log(format!(
         "{} took {} damage (Str {}).",
@@ -374,5 +380,24 @@ mod tests {
 
         // We assume removal = more damage, since it's a bit tricky to test due to RNG
         assert!(!ecs.has_status(&player, StatusKind::Aimed));
+    }
+
+    #[test]
+    fn armored_adds_armor_one_hit() {
+        let mut ecs = create_test_state().with_player(2, 2, 100).with_character(2, 3, 0).with_map().build();
+        let player = find_at(&ecs, 2, 2);
+        let target = find_at(&ecs, 2, 3);
+
+        ecs.add_status(&target, StatusKind::Armored, 300);
+
+        begin_bolt(&mut ecs, &player, Point::init(2, 3), Damage::init(3), BoltKind::Fire);
+        wait_for_animations(&mut ecs);
+
+        // 3 armor, 3 damage
+        // Damage: 2 + [2,4] = 4-6
+        // Armor: 2 + [2,4] = 4-6
+        // 0 - 2 damage
+        let health = &ecs.get_defenses(&target);
+        assert!(health.health > 7);
     }
 }

--- a/src/clash/damage.rs
+++ b/src/clash/damage.rs
@@ -104,10 +104,7 @@ fn apply_damage_core(ecs: &mut World, damage: Damage, target: &Entity, source_po
         if rolled_damage.options.contains(DamageOptions::KNOCKBACK) {
             true
         } else if rolled_damage.options.contains(DamageOptions::CONSUMES_CHARGE_KNOCKBACK) && ecs.has_status(target, StatusKind::StaticCharge) {
-            ecs.write_storage::<StatusComponent>()
-                .grab_mut(*target)
-                .status
-                .remove_status(StatusKind::StaticCharge);
+            ecs.remove_status(target, StatusKind::StaticCharge);
             true
         } else {
             false
@@ -129,10 +126,7 @@ fn apply_damage_core(ecs: &mut World, damage: Damage, target: &Entity, source_po
     }
     if rolled_damage.options.contains(DamageOptions::ADD_CHARGE_STATUS) && !ecs.has_status(target, StatusKind::StaticCharge) {
         ecs.log(format!("{} crackles with static electricity", ecs.get_name(target).unwrap()));
-        ecs.write_storage::<StatusComponent>()
-            .grab_mut(*target)
-            .status
-            .add_status(StatusKind::StaticCharge, 300);
+        ecs.add_status(target, StatusKind::StaticCharge, 300);
     }
     if rolled_damage.options.contains(DamageOptions::CONSUMES_CHARGE_DMG) && ecs.has_status(target, StatusKind::StaticCharge) {
         const STATIC_CHARGE_DAMAGE: u32 = 4;
@@ -142,10 +136,7 @@ fn apply_damage_core(ecs: &mut World, damage: Damage, target: &Entity, source_po
             target,
             None,
         );
-        ecs.write_storage::<StatusComponent>()
-            .grab_mut(*target)
-            .status
-            .remove_status(StatusKind::StaticCharge);
+        ecs.remove_status(target, StatusKind::StaticCharge);
     }
 
     if rolled_damage.options.contains(DamageOptions::AIMED_SHOT) {
@@ -153,10 +144,7 @@ fn apply_damage_core(ecs: &mut World, damage: Damage, target: &Entity, source_po
             if let Some(source) = find_character_at_location(ecs, source_position) {
                 if !ecs.has_status(&source, StatusKind::Aimed) {
                     ecs.log(format!("{} takes aim", ecs.get_name(&source).unwrap()));
-                    ecs.write_storage::<StatusComponent>()
-                        .grab_mut(source)
-                        .status
-                        .add_status(StatusKind::Aimed, 300);
+                    ecs.add_status(&source, StatusKind::Aimed, 300);
                 }
             }
         }
@@ -260,10 +248,7 @@ mod tests {
         let player = find_at(&ecs, 2, 2);
         let target = find_at(&ecs, 2, 3);
 
-        ecs.write_storage::<StatusComponent>()
-            .grab_mut(target)
-            .status
-            .add_status(StatusKind::StaticCharge, 100);
+        ecs.add_status(&target, StatusKind::StaticCharge, 300);
 
         begin_bolt(
             &mut ecs,
@@ -285,10 +270,7 @@ mod tests {
         let player = find_at(&ecs, 2, 2);
         let target = find_at(&ecs, 2, 3);
 
-        ecs.write_storage::<StatusComponent>()
-            .grab_mut(target)
-            .status
-            .add_status(StatusKind::StaticCharge, 100);
+        ecs.add_status(&target, StatusKind::StaticCharge, 300);
 
         begin_bolt(
             &mut ecs,
@@ -385,10 +367,7 @@ mod tests {
         let mut ecs = create_test_state().with_player(2, 2, 100).with_character(2, 3, 0).with_map().build();
         let player = find_at(&ecs, 2, 2);
 
-        ecs.write_storage::<StatusComponent>()
-            .grab_mut(player)
-            .status
-            .add_status(StatusKind::Aimed, 300);
+        ecs.add_status(&player, StatusKind::Aimed, 300);
 
         begin_bolt(&mut ecs, &player, Point::init(2, 3), Damage::init(3), BoltKind::Fire);
         wait_for_animations(&mut ecs);

--- a/src/clash/physics.rs
+++ b/src/clash/physics.rs
@@ -274,7 +274,8 @@ mod tests {
     fn frozen_slows_movement() {
         let mut ecs = create_test_state().with_character(2, 2, 100).with_map().build();
         let player = find_at(&ecs, 2, 2);
-        ecs.write_storage::<StatusComponent>().grab_mut(player).status.add_trait(StatusKind::Frozen);
+        ecs.add_trait(&player, StatusKind::Frozen);
+
         // All of these tests by default do not include an SkillResourceComponent, so they get no exhaustion
         let skill_resource = SkillResourceComponent {
             exhaustion: 0.0,

--- a/src/clash/skills.rs
+++ b/src/clash/skills.rs
@@ -35,6 +35,7 @@ pub enum SkillEffect {
 #[derive(Clone, Copy, PartialEq, Eq, Hash, IntoEnumIterator, Debug, Deserialize, Serialize)]
 pub enum AmmoKind {
     Bullets,
+    Adrenaline,
 }
 
 pub struct AmmoInfo {
@@ -43,11 +44,12 @@ pub struct AmmoInfo {
 }
 
 impl SkillResourceComponent {
-    pub fn init(starting_ammo: &[(AmmoKind, u32)]) -> SkillResourceComponent {
-        let ammo: HashMap<AmmoKind, u32> = starting_ammo.iter().map(|(k, a)| (*k, *a)).collect();
+    pub fn init(starting_ammo: &[(AmmoKind, u32, u32)]) -> SkillResourceComponent {
+        let ammo: HashMap<AmmoKind, u32> = starting_ammo.iter().map(|(kind, starting, _)| (*kind, *starting)).collect();
+        let max: HashMap<AmmoKind, u32> = starting_ammo.iter().map(|(kind, _, max)| (*kind, *max)).collect();
         SkillResourceComponent {
-            max: ammo.clone(),
             ammo,
+            max,
             exhaustion: 0.0,
             focus: 0.0,
             max_focus: 0.0,
@@ -545,7 +547,7 @@ mod tests {
     }
 
     fn add_bullets(ecs: &mut World, player: &Entity, count: u32) {
-        let resource = SkillResourceComponent::init(&[(AmmoKind::Bullets, count)]);
+        let resource = SkillResourceComponent::init(&[(AmmoKind::Bullets, count, count)]);
         ecs.shovel(*player, resource);
     }
 

--- a/src/clash/status.rs
+++ b/src/clash/status.rs
@@ -19,6 +19,7 @@ pub enum StatusKind {
     Cyclone,
     StaticCharge,
     Aimed,
+    Armored,
 
     #[cfg(test)]
     TestStatus,
@@ -184,7 +185,6 @@ pub fn status_event(ecs: &mut World, kind: EventKind, target: Option<Entity>) {
 mod tests {
     use super::super::*;
     use super::*;
-    use crate::atlas::EasyMutECS;
 
     #[test]
     fn add_status() {

--- a/src/clash/status.rs
+++ b/src/clash/status.rs
@@ -285,10 +285,7 @@ mod tests {
     fn status_integration_with_ecs() {
         let mut ecs = create_test_state().with_character(2, 2, 100).build();
         let entity = find_at(&ecs, 2, 2);
-        ecs.write_storage::<StatusComponent>()
-            .grab_mut(entity)
-            .status
-            .add_status(StatusKind::TestStatus, 100);
+        ecs.add_status(&entity, StatusKind::TestStatus, 100);
         assert!(ecs.has_status(&entity, StatusKind::TestStatus));
         add_ticks(&mut ecs, 100);
         assert!(!ecs.has_status(&entity, StatusKind::TestStatus));

--- a/src/clash/temperature.rs
+++ b/src/clash/temperature.rs
@@ -91,10 +91,7 @@ fn check_temperature_state(ecs: &mut World, target: &Entity) {
 
     if ecs.get_temperature(target).is_burning() && !ecs.has_status(target, StatusKind::Burning) {
         ecs.log(format!("{} begins to burn", ecs.get_name(target).unwrap()));
-        ecs.write_storage::<StatusComponent>()
-            .grab_mut(*target)
-            .status
-            .add_status(StatusKind::Burning, BURN_DURATION);
+        ecs.add_status(target, StatusKind::Burning, BURN_DURATION);
     }
 }
 
@@ -152,10 +149,7 @@ pub fn temp_event(ecs: &mut World, kind: EventKind, target: Option<Entity>) {
                 // Order matter here - must re-apply burning status before apply damage,
                 // else we'll repeat "began burning" log
                 if ecs.get_temperature(&target.unwrap()).is_burning() {
-                    ecs.write_storage::<StatusComponent>()
-                        .grab_mut(target.unwrap())
-                        .status
-                        .add_status(StatusKind::Burning, BURN_DURATION);
+                    ecs.add_status(&target.unwrap(), StatusKind::Burning, BURN_DURATION);
                 } else {
                     ecs.log(format!("{} stops burning", ecs.get_name(&target.unwrap()).unwrap()));
                 }


### PR DESCRIPTION
- Add 3 utility skills (Reload, Move, Shoot).
- Add BuffThen and ThenBuff skill action types.
- Add Armored status
- Add "instant" skills
- Add helpers methods for add/remove status and remove duplicated code.