### PR TITLE
Stop some fowl play (Enable phase 1 bird and fix a bunch of orb issues)

### DIFF
--- a/src/arena/spawner.rs
+++ b/src/arena/spawner.rs
@@ -42,7 +42,7 @@ pub fn bird_monster(ecs: &mut World) {
             Temperature::init(),
         )))
         .with(StatusComponent::init())
-        .with(BehaviorComponent::init(BehaviorKind::Bird(0)))
+        .with(BehaviorComponent::init(BehaviorKind::Bird))
         .with(TimeComponent::init(0))
         .marked::<SimpleMarker<ToSerialize>>()
         .build();

--- a/src/clash/ai.rs
+++ b/src/clash/ai.rs
@@ -12,7 +12,7 @@ use crate::atlas::{EasyECS, SizedPoint};
 pub enum BehaviorKind {
     None,
     Random,
-    Bird(u32),
+    Bird,
     Explode,
     Orb,
 }
@@ -24,7 +24,7 @@ pub fn take_enemy_action(ecs: &mut World, enemy: &Entity) {
         BehaviorKind::Random => {
             move_randomly(ecs, enemy);
         }
-        BehaviorKind::Bird(phase) => super::content::bird::take_action(ecs, enemy, phase),
+        BehaviorKind::Bird => super::content::bird::take_action(ecs, enemy),
         BehaviorKind::Explode => {
             begin_explode(ecs, &enemy);
         }

--- a/src/clash/ai.rs
+++ b/src/clash/ai.rs
@@ -67,6 +67,15 @@ pub fn move_randomly(ecs: &mut World, enemy: &Entity) -> bool {
     }
 }
 
+pub fn use_skill(ecs: &mut World, enemy: &Entity, skill_name: &str) -> bool {
+    if can_invoke_skill(ecs, enemy, get_skill(skill_name), None) {
+        invoke_skill(ecs, enemy, skill_name, None);
+        true
+    } else {
+        false
+    }
+}
+
 pub fn use_skill_if_in_range(ecs: &mut World, enemy: &Entity, skill_name: &str) -> bool {
     let current_position = ecs.get_position(enemy);
     let player_position = ecs.get_position(&find_player(ecs));

--- a/src/clash/ai.rs
+++ b/src/clash/ai.rs
@@ -67,6 +67,7 @@ pub fn move_randomly(ecs: &mut World, enemy: &Entity) -> bool {
     }
 }
 
+#[allow(dead_code)]
 pub fn use_skill(ecs: &mut World, enemy: &Entity, skill_name: &str) -> bool {
     if can_invoke_skill(ecs, enemy, get_skill(skill_name), None) {
         invoke_skill(ecs, enemy, skill_name, None);

--- a/src/clash/ai.rs
+++ b/src/clash/ai.rs
@@ -82,6 +82,12 @@ pub fn use_skill_if_in_range(ecs: &mut World, enemy: &Entity, skill_name: &str) 
     false
 }
 
+pub fn distance_to_player(ecs: &mut World, enemy: &Entity) -> Option<u32> {
+    let current_position = ecs.get_position(enemy);
+    let player_position = ecs.get_position(&find_player(ecs));
+    current_position.distance_to_multi(player_position)
+}
+
 pub fn move_towards_player(ecs: &mut World, enemy: &Entity) -> bool {
     let current_position = ecs.get_position(enemy);
     let player_position = ecs.get_position(&find_player(ecs));

--- a/src/clash/combat.rs
+++ b/src/clash/combat.rs
@@ -327,7 +327,7 @@ pub fn start_orb(ecs: &mut World, source: Entity) {
     let target_position = attack.target;
     let path = source_position.line_to(target_position).unwrap();
 
-    let orb = create_orb(ecs, attack, &path, &path[1]);
+    let orb = create_orb(ecs, &source, attack, &path);
 
     ecs.write_storage::<AttackComponent>().remove(source);
     ecs.raise_event(EventKind::Orb(OrbState::Created), Some(orb));
@@ -623,5 +623,23 @@ mod tests {
         new_turn_wait_characters(&mut ecs);
         assert!(ecs.get_defenses(&bystander).health < bystander_starting_health);
         assert_eq!(ecs.get_defenses(&target).health, target_starting_health);
+    }
+
+    #[test]
+    fn orb_from_multi_square_sourced() {
+        let mut ecs = create_test_state()
+            .with_player(2, 2, 0)
+            .with_sized_character(SizedPoint::init_multi(2, 6, 2, 2), 0)
+            .with_map()
+            .build();
+        let player = find_at(&ecs, 2, 2);
+        let enemy = find_at(&ecs, 2, 6);
+        let player_starting_health = ecs.get_defenses(&player).health;
+
+        begin_orb(&mut ecs, &enemy, Point::init(2, 2), Damage::init(2), OrbKind::Feather, 2);
+        wait_for_animations(&mut ecs);
+
+        new_turn_wait_characters(&mut ecs);
+        assert!(ecs.get_defenses(&player).health < player_starting_health);
     }
 }

--- a/src/clash/combat.rs
+++ b/src/clash/combat.rs
@@ -503,6 +503,7 @@ mod tests {
 
         new_turn_wait_characters(&mut ecs);
         assert!(ecs.get_defenses(&target).health < starting_health);
+        assert_eq!(0, ecs.read_storage::<OrbComponent>().count());
     }
 
     #[test]
@@ -518,6 +519,7 @@ mod tests {
 
         new_turn_wait_characters(&mut ecs);
         assert!(ecs.get_defenses(&target).health < starting_health);
+        assert_eq!(0, ecs.read_storage::<OrbComponent>().count());
     }
 
     #[test]
@@ -539,6 +541,7 @@ mod tests {
 
         new_turn_wait_characters(&mut ecs);
         assert_eq!(ecs.get_defenses(&target).health, starting_health);
+        assert_eq!(0, ecs.read_storage::<OrbComponent>().count());
     }
 
     #[test]

--- a/src/clash/components.rs
+++ b/src/clash/components.rs
@@ -145,11 +145,15 @@ pub struct AttackComponent {
 #[derive(Component, ConvertSaveload, Clone)]
 pub struct BehaviorComponent {
     pub behavior: BehaviorKind,
+    pub info: HashMap<String, u32>,
 }
 
 impl BehaviorComponent {
     pub fn init(behavior: BehaviorKind) -> BehaviorComponent {
-        BehaviorComponent { behavior }
+        BehaviorComponent {
+            behavior,
+            info: HashMap::new(),
+        }
     }
 }
 

--- a/src/clash/content/bird.rs
+++ b/src/clash/content/bird.rs
@@ -7,7 +7,7 @@ use crate::try_behavior;
 
 pub fn bird_skills(m: &mut HashMap<&'static str, SkillInfo>) {
     m.insert(
-        "Feather Blast",
+        "Wing Blast",
         SkillInfo::init_with_distance(
             None,
             TargetType::Player,
@@ -16,10 +16,18 @@ pub fn bird_skills(m: &mut HashMap<&'static str, SkillInfo>) {
             true,
         ),
     );
+    m.insert(
+        "Feather Orb",
+        SkillInfo::init_with_distance(None, TargetType::Player, SkillEffect::Orb(Damage::init(4), OrbKind::Feather, 2), Some(12), true),
+    );
 }
 
 pub fn take_action(ecs: &mut World, enemy: &Entity) {
-    try_behavior!(use_skill_if_in_range(ecs, enemy, "Feather Blast"));
+    if distance_to_player(ecs, enemy).unwrap_or(0) > 3 {
+        try_behavior!(use_skill_if_in_range(ecs, enemy, "Feather Orb"));
+    } else {
+        try_behavior!(use_skill_if_in_range(ecs, enemy, "Wing Blast"));
+    }
     try_behavior!(move_towards_player(ecs, enemy));
     try_behavior!(move_randomly(ecs, enemy));
 

--- a/src/clash/content/bird.rs
+++ b/src/clash/content/bird.rs
@@ -18,12 +18,10 @@ pub fn bird_skills(m: &mut HashMap<&'static str, SkillInfo>) {
     );
 }
 
-pub fn take_action(ecs: &mut World, enemy: &Entity, phase: u32) {
-    if phase == 1 {
-        try_behavior!(use_skill_if_in_range(ecs, enemy, "Feather Blast"));
-        try_behavior!(move_towards_player(ecs, enemy));
-        try_behavior!(move_randomly(ecs, enemy));
-    }
+pub fn take_action(ecs: &mut World, enemy: &Entity) {
+    try_behavior!(use_skill_if_in_range(ecs, enemy, "Feather Blast"));
+    try_behavior!(move_towards_player(ecs, enemy));
+    try_behavior!(move_randomly(ecs, enemy));
 
     wait(ecs, *enemy);
 }

--- a/src/clash/content/test.rs
+++ b/src/clash/content/test.rs
@@ -68,6 +68,9 @@ pub fn add_test_skills(m: &mut HashMap<&'static str, SkillInfo>) {
             true,
         ),
     );
+
+    m.insert("Buff", SkillInfo::init(None, TargetType::None, SkillEffect::Buff(StatusKind::Aimed, 300)));
+
     m.insert(
         "BuffAndMove",
         SkillInfo::init_with_distance(

--- a/src/clash/orb.rs
+++ b/src/clash/orb.rs
@@ -61,7 +61,7 @@ fn add_orb_movement_fields(ecs: &mut World, path: &[Point], speed: u32, current:
             if i < speed as usize {
                 (255, 0, 0)
             } else {
-                (128, 128, 0)
+                (230, 150, 0)
             }
         };
 

--- a/src/clash/orb.rs
+++ b/src/clash/orb.rs
@@ -48,7 +48,7 @@ pub fn create_orb(ecs: &mut World, invoker: &Entity, attack: AttackInfo, path: &
         .with(AttackComponent { attack })
         .with(OrbComponent::init(path.to_vec(), speed))
         .with(BehaviorComponent::init(BehaviorKind::Orb))
-        .with(TimeComponent::init(-100))
+        .with(TimeComponent::init(0))
         .build();
 
     add_orb_movement_fields(ecs, &path, speed, starting_index);

--- a/src/clash/orb.rs
+++ b/src/clash/orb.rs
@@ -56,11 +56,19 @@ pub fn create_orb(ecs: &mut World, invoker: &Entity, attack: AttackInfo, path: &
 }
 
 fn add_orb_movement_fields(ecs: &mut World, path: &[Point], speed: u32, current: usize) {
-    for i in 0..speed as usize {
+    for i in 0..2 * speed as usize {
+        let (r, g, b) = {
+            if i < speed as usize {
+                (255, 0, 0)
+            } else {
+                (128, 128, 0)
+            }
+        };
+
         if let Some(field) = path.get(current + i + 1) {
             ecs.create_entity()
                 .with(PositionComponent::init(SizedPoint::from(*field)))
-                .with(FieldComponent::init(255, 0, 0))
+                .with(FieldComponent::init(r, g, b))
                 .with(OrbComponent::init(path.to_vec(), speed))
                 .build();
         }
@@ -112,7 +120,8 @@ mod tests {
         wait_for_animations(&mut ecs);
         assert_field_exists(&ecs, 2, 4);
         assert_field_exists(&ecs, 2, 5);
-        assert_field_count(&ecs, 2);
+        assert_field_exists(&ecs, 2, 6);
+        assert_field_count(&ecs, 3);
     }
 
     #[test]
@@ -163,10 +172,12 @@ mod tests {
         begin_orb(&mut ecs, &player, Point::init(2, 10), Damage::init(2), OrbKind::Feather, 2);
         wait_for_animations(&mut ecs);
 
-        for _ in 0..3 {
-            assert_field_count(&ecs, 2);
+        for _ in 0..2 {
+            assert_field_count(&ecs, 4);
             new_turn_wait_characters(&mut ecs);
         }
+        assert_field_count(&ecs, 3);
+        new_turn_wait_characters(&mut ecs);
         assert_field_count(&ecs, 1);
         new_turn_wait_characters(&mut ecs);
         assert_field_count(&ecs, 0);

--- a/src/clash/orb.rs
+++ b/src/clash/orb.rs
@@ -32,11 +32,14 @@ pub fn move_orb(ecs: &mut World, entity: &Entity) {
     begin_move(ecs, entity, SizedPoint::from(path[next_index]), PostMoveAction::None);
 }
 
-pub fn create_orb(ecs: &mut World, attack: AttackInfo, path: &[Point], position: &Point) -> Entity {
+pub fn create_orb(ecs: &mut World, invoker: &Entity, attack: AttackInfo, path: &[Point]) -> Entity {
+    let caster_position = ecs.get_position(invoker);
+    let starting_index = path.iter().position(|x| !caster_position.contains_point(x)).unwrap();
+
     let speed = attack.orb_speed();
     let orb = ecs
         .create_entity()
-        .with(PositionComponent::init(SizedPoint::from(*position)))
+        .with(PositionComponent::init(SizedPoint::from(path[starting_index])))
         .with(AttackComponent { attack })
         .with(OrbComponent::init(path.to_vec(), speed))
         .with(BehaviorComponent::init(BehaviorKind::Orb))


### PR DESCRIPTION
- Add buff only skills, AI can use non-targtted skills 
- Orbs should be placed outside of mulit-square entities
- Orbs die at end of path.
- Show correct fields for large enemies
- Set orbs start time correctly
- Show orbs at 2x speed distant. Either red or yellow 