### PR TITLE
Hurry up and wait for a bunch of orb fixes 

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -2,6 +2,7 @@
 // The scene and UX
 mod animations;
 mod battle_actions;
+pub use battle_actions::BattleActionRequest;
 mod battle_animations;
 mod battle_scene;
 

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -17,7 +17,7 @@ use sprite_loader::SpriteLoader;
 pub use battle_scene::BattleScene;
 
 #[cfg(test)]
-pub use animations::complete_animations;
+pub use animations::force_complete_animations;
 #[cfg(test)]
 pub use components::add_ui_extension;
 

--- a/src/arena/animations.rs
+++ b/src/arena/animations.rs
@@ -132,7 +132,7 @@ pub fn tick_animations(ecs: &mut World, frame: u64) {
     }
 
     // Remove must occur before notification, in case a notification
-    // adds a new animatino
+    // adds a new animation
     for entity in &completed {
         ecs.write_storage::<AnimationComponent>().remove(*entity);
     }
@@ -142,7 +142,7 @@ pub fn tick_animations(ecs: &mut World, frame: u64) {
     }
 }
 
-pub fn complete_animations(ecs: &mut World) {
+pub fn force_complete_animations(ecs: &mut World) {
     loop {
         let current_frame = {
             ecs.write_resource::<crate::clash::FrameComponent>().current_frame += 1;

--- a/src/arena/animations.rs
+++ b/src/arena/animations.rs
@@ -144,7 +144,7 @@ pub fn tick_animations(ecs: &mut World, frame: u64) {
 
 pub fn add_animation(ecs: &mut World, entity: Entity, mut animation: Animation) {
     if ecs.read_resource::<AccelerateAnimations>().state {
-        animation.duration = animation.duration / 4;
+        animation.duration /= 4;
     }
     ecs.shovel(entity, AnimationComponent::init(animation));
 }
@@ -167,7 +167,7 @@ pub fn accelerate_animations(ecs: &mut World) {
     for a in to_speedup {
         let mut animations = ecs.write_storage::<AnimationComponent>();
         let animation = &mut animations.grab_mut(a).animation;
-        animation.duration = animation.duration / 4;
+        animation.duration /= 4;
     }
     ecs.write_resource::<AccelerateAnimations>().state = true;
 }

--- a/src/arena/animations.rs
+++ b/src/arena/animations.rs
@@ -152,22 +152,16 @@ pub fn add_animation(ecs: &mut World, entity: Entity, mut animation: Animation) 
 pub fn accelerate_animations(ecs: &mut World) {
     let mut to_speedup = vec![];
     {
-        let frame = ecs.get_current_frame();
         let entities = ecs.read_resource::<specs::world::EntitiesRes>();
         let animations = ecs.read_storage::<AnimationComponent>();
 
-        for (entity, animation_component) in (&entities, &animations).join() {
-            let animation = &animation_component.animation;
-            if !animation.is_complete(frame) {
-                to_speedup.push(entity);
-            }
+        for (entity, _) in (&entities, &animations).join() {
+            to_speedup.push(entity);
         }
     }
 
     for a in to_speedup {
-        let mut animations = ecs.write_storage::<AnimationComponent>();
-        let animation = &mut animations.grab_mut(a).animation;
-        animation.duration /= 4;
+        ecs.write_storage::<AnimationComponent>().grab_mut(a).animation.duration /= 4;
     }
     ecs.write_resource::<AccelerateAnimations>().state = true;
 }

--- a/src/arena/animations.rs
+++ b/src/arena/animations.rs
@@ -154,7 +154,6 @@ pub fn accelerate_animations(ecs: &mut World) {
     {
         let entities = ecs.read_resource::<specs::world::EntitiesRes>();
         let animations = ecs.read_storage::<AnimationComponent>();
-
         for (entity, _) in (&entities, &animations).join() {
             to_speedup.push(entity);
         }

--- a/src/arena/animations.rs
+++ b/src/arena/animations.rs
@@ -3,7 +3,7 @@ use specs::prelude::*;
 use super::{AccelerateAnimations, AnimationComponent};
 use crate::after_image::CharacterAnimationState;
 use crate::atlas::{EasyMutECS, EasyMutWorld, Point};
-use crate::clash::{EventCoordinator, EventKind, Framer};
+use crate::clash::{EventCoordinator, EventKind};
 
 #[derive(PartialEq)]
 pub struct FPoint {

--- a/src/arena/battle_actions.rs
+++ b/src/arena/battle_actions.rs
@@ -6,7 +6,7 @@ use crate::atlas::{Direction, EasyECS, Point};
 use crate::clash::*;
 
 pub enum BattleActionRequest {
-    None
+    None,
     SelectSkill(String),
     Move(Direction),
 }
@@ -15,22 +15,6 @@ pub enum BattleActionRequest {
 pub fn has_animations_blocking(ecs: &World) -> bool {
     let animations = ecs.read_storage::<AnimationComponent>();
     (&animations).join().count() > 0
-}
-
-pub fn get_skill_name(ecs: &World, index: usize) -> Option<String> {
-    let skills_component = ecs.read_storage::<SkillsComponent>();
-    let skills = &skills_component.grab(find_player(&ecs)).skills;
-    skills.get(index).map(|s| get_current_skill(ecs, s))
-}
-
-// Some skills have an alternate when not usable (such as reload)
-pub fn get_current_skill(ecs: &World, skill_name: &str) -> String {
-    let skill = get_skill(skill_name);
-
-    match skill.is_usable(ecs, &find_player(&ecs)) {
-        UsableResults::LacksAmmo if skill.alternate.is_some() => skill.alternate.as_ref().unwrap().to_string(),
-        _ => skill_name.to_string(),
-    }
 }
 
 pub fn select_skill(ecs: &mut World, name: &str) {

--- a/src/arena/battle_actions.rs
+++ b/src/arena/battle_actions.rs
@@ -5,6 +5,12 @@ use super::AnimationComponent;
 use crate::atlas::{Direction, EasyECS, Point};
 use crate::clash::*;
 
+pub enum BattleActionRequest {
+    None
+    SelectSkill(String),
+    Move(Direction),
+}
+
 // Prevents actions when animations in progress. actions::can_act handles world state
 pub fn has_animations_blocking(ecs: &World) -> bool {
     let animations = ecs.read_storage::<AnimationComponent>();
@@ -52,10 +58,6 @@ pub fn select_skill(ecs: &mut World, name: &str) {
 }
 
 pub fn select_skill_with_target(ecs: &mut World, name: &str, position: &Point) {
-    if has_animations_blocking(ecs) {
-        return;
-    }
-
     // Selection has been made, drop out of targeting state
     reset_state(ecs);
 

--- a/src/arena/battle_actions.rs
+++ b/src/arena/battle_actions.rs
@@ -13,9 +13,14 @@ pub enum BattleActionRequest {
 }
 
 pub fn request_action(ecs: &mut World, request: BattleActionRequest) {
+    ecs.write_resource::<AccelerateAnimations>().state = false;
+
     let animation_blocked = has_animations_blocking(ecs);
     let action_blocked = !can_act(ecs);
-    if animation_blocked || action_blocked {
+    if animation_blocked {
+        super::animations::accelerate_animations(ecs);
+    }
+    if animation_blocked || !action_blocked {
         ecs.write_resource::<BufferedInputComponent>().input = Some(request);
     } else {
         process_action(ecs, request);

--- a/src/arena/battle_actions.rs
+++ b/src/arena/battle_actions.rs
@@ -5,6 +5,7 @@ use super::AnimationComponent;
 use crate::atlas::{Direction, EasyECS, Point};
 use crate::clash::*;
 
+// Prevents actions when animations in progress. actions::can_act handles world state
 pub fn has_animations_blocking(ecs: &World) -> bool {
     let animations = ecs.read_storage::<AnimationComponent>();
     (&animations).join().count() > 0

--- a/src/arena/battle_actions.rs
+++ b/src/arena/battle_actions.rs
@@ -13,7 +13,9 @@ pub enum BattleActionRequest {
 }
 
 pub fn request_action(ecs: &mut World, request: BattleActionRequest) {
-    if has_animations_blocking(ecs) {
+    let animation_blocked = has_animations_blocking(ecs);
+    let action_blocked = !can_act(ecs);
+    if animation_blocked || action_blocked {
         ecs.write_resource::<BufferedInputComponent>().input = Some(request);
     } else {
         process_action(ecs, request);

--- a/src/arena/battle_actions.rs
+++ b/src/arena/battle_actions.rs
@@ -34,7 +34,9 @@ pub fn select_skill(ecs: &mut World, name: &str) {
         player_use_skill(ecs, name, None);
     } else {
         match target_required {
-            TargetType::Any | TargetType::Enemy | TargetType::Tile => set_state(ecs, BattleSceneState::Targeting(BattleTargetSource::Skill(name.to_string()))),
+            TargetType::Any | TargetType::Enemy | TargetType::Tile => {
+                set_action_state(ecs, BattleSceneState::Targeting(BattleTargetSource::Skill(name.to_string())))
+            }
             TargetType::Player => panic!("TargetType::Player should not have reached here in select_skill"),
             TargetType::None => panic!("TargetType::None should not have reached here in select_skill"),
         }
@@ -43,7 +45,7 @@ pub fn select_skill(ecs: &mut World, name: &str) {
 
 pub fn select_skill_with_target(ecs: &mut World, name: &str, position: &Point) {
     // Selection has been made, drop out of targeting state
-    reset_state(ecs);
+    reset_action_state(ecs);
 
     let skill = get_skill(name);
 
@@ -59,15 +61,15 @@ pub fn select_skill_with_target(ecs: &mut World, name: &str, position: &Point) {
     }
 }
 
-pub fn read_state(ecs: &World) -> BattleSceneState {
+pub fn read_action_state(ecs: &World) -> BattleSceneState {
     ecs.read_resource::<BattleSceneStateComponent>().state.clone()
 }
 
-pub fn set_state(ecs: &mut World, state: BattleSceneState) {
+pub fn set_action_state(ecs: &mut World, state: BattleSceneState) {
     ecs.write_resource::<BattleSceneStateComponent>().state = state;
 }
 
-pub fn reset_state(ecs: &mut World) {
+pub fn reset_action_state(ecs: &mut World) {
     let mut state = ecs.write_resource::<BattleSceneStateComponent>();
     state.state = BattleSceneState::Default();
 }

--- a/src/arena/battle_animations.rs
+++ b/src/arena/battle_animations.rs
@@ -1,7 +1,7 @@
 use specs::prelude::*;
 
 use super::components::*;
-use super::{add_animation, Animation, AnimationComponent};
+use super::{add_animation, Animation};
 
 use crate::after_image::CharacterAnimationState;
 use crate::atlas::{EasyECS, EasyMutWorld, Point};

--- a/src/arena/battle_animations.rs
+++ b/src/arena/battle_animations.rs
@@ -1,7 +1,7 @@
 use specs::prelude::*;
 
 use super::components::*;
-use super::{Animation, AnimationComponent};
+use super::{add_animation, Animation, AnimationComponent};
 
 use crate::after_image::CharacterAnimationState;
 use crate::atlas::{EasyECS, EasyMutWorld, Point};
@@ -28,7 +28,7 @@ pub fn cast_animation(ecs: &mut World, target: Entity, animation: CharacterAnima
 
     const CAST_LENGTH: u64 = 18;
     let cast_animation = Animation::sprite_state(animation, CharacterAnimationState::Idle, frame, CAST_LENGTH).with_post_event(post_event, Some(target));
-    ecs.shovel(target, AnimationComponent::init(cast_animation));
+    add_animation(ecs, target, cast_animation);
 }
 
 pub fn projectile_animation(ecs: &mut World, projectile: Entity, target_position: Point, sprite: SpriteKinds, post_event: EventKind) {
@@ -41,7 +41,7 @@ pub fn projectile_animation(ecs: &mut World, projectile: Entity, target_position
     let animation_length = if frame < 4 { 6 * path_length } else { 3 * path_length };
 
     let animation = Animation::movement(source_position.origin, target_position, frame, animation_length).with_post_event(post_event, Some(projectile));
-    ecs.shovel(projectile, AnimationComponent::init(animation));
+    add_animation(ecs, projectile, animation);
 }
 
 pub fn begin_ranged_cast_animation(ecs: &mut World, target: Entity) {
@@ -147,7 +147,7 @@ pub fn begin_melee_animation(ecs: &mut World, target: Entity) {
     const MELEE_ATTACK_LENGTH: u64 = 18;
     let attack_animation = Animation::sprite_state(animation, CharacterAnimationState::Idle, frame, MELEE_ATTACK_LENGTH)
         .with_post_event(EventKind::Melee(MeleeState::CompleteAnimation), Some(target));
-    ecs.shovel(target, AnimationComponent::init(attack_animation));
+    add_animation(ecs, target, attack_animation);
 }
 
 pub fn move_event(ecs: &mut World, kind: EventKind, target: Option<Entity>) {
@@ -173,7 +173,7 @@ fn animate_move(ecs: &mut World, target: Entity, action: PostMoveAction) {
 
     let animation = Animation::movement(position.origin, new_position.origin, frame, MOVE_LENGTH)
         .with_post_event(EventKind::Move(MoveState::CompleteAnimation, action), Some(target));
-    ecs.shovel(target, AnimationComponent::init(animation));
+    add_animation(ecs, target, animation);
 }
 
 pub fn explode_event(ecs: &mut World, kind: EventKind, target: Option<Entity>) {
@@ -189,5 +189,5 @@ pub fn begin_explode_animation(ecs: &mut World, target: Entity) {
 
     const EXPLOSION_LENGTH: u64 = 18;
     let attack_animation = Animation::empty(frame, EXPLOSION_LENGTH).with_post_event(EventKind::Explode(ExplodeState::CompleteAnimation), Some(target));
-    ecs.shovel(target, AnimationComponent::init(attack_animation));
+    add_animation(ecs, target, attack_animation);
 }

--- a/src/arena/battle_scene.rs
+++ b/src/arena/battle_scene.rs
@@ -49,7 +49,7 @@ impl BattleScene {
     fn handle_default_key(&mut self, keycode: Keycode) {
         if cfg!(debug_assertions) {
             if keycode == Keycode::F1 {
-                battle_actions::set_state(&mut self.ecs, BattleSceneState::Debug(DebugKind::MapOverlay()));
+                battle_actions::set_action_state(&mut self.ecs, BattleSceneState::Debug(DebugKind::MapOverlay()));
             }
         }
 
@@ -75,7 +75,7 @@ impl BattleScene {
 
     fn handle_target_key(&mut self, keycode: Keycode) {
         if keycode == Keycode::Escape {
-            battle_actions::reset_state(&mut self.ecs)
+            battle_actions::reset_action_state(&mut self.ecs)
         }
 
         // If they select a skill, start a new target session just like
@@ -88,7 +88,7 @@ impl BattleScene {
 
     fn handle_debug_key(&mut self, kind: DebugKind, keycode: Keycode) {
         if keycode == Keycode::Escape {
-            battle_actions::reset_state(&mut self.ecs);
+            battle_actions::reset_action_state(&mut self.ecs);
             return;
         }
         if kind.is_map_overlay() {
@@ -110,11 +110,11 @@ impl BattleScene {
 
     fn handle_target_mouse(&mut self, x: i32, y: i32, button: MouseButton) {
         if button == MouseButton::Right {
-            battle_actions::reset_state(&mut self.ecs);
+            battle_actions::reset_action_state(&mut self.ecs);
             return;
         }
 
-        let target_info = match battle_actions::read_state(&self.ecs) {
+        let target_info = match battle_actions::read_action_state(&self.ecs) {
             BattleSceneState::Targeting(target_source) => Some(target_source),
             _ => None,
         };
@@ -171,7 +171,7 @@ impl Scene for BattleScene {
                 }
             }
 
-            let state = battle_actions::read_state(&self.ecs);
+            let state = battle_actions::read_action_state(&self.ecs);
             match state {
                 BattleSceneState::Default() => self.handle_default_mouse(x, y, button),
                 BattleSceneState::Targeting(_) => self.handle_target_mouse(x, y, button),

--- a/src/arena/battle_scene.rs
+++ b/src/arena/battle_scene.rs
@@ -54,7 +54,7 @@ impl BattleScene {
         }
 
         if let Some(i) = is_keystroke_skill(keycode) {
-            if let Some(name) = battle_actions::get_skill_name(&self.ecs, i as usize) {
+            if let Some(name) = super::views::get_skill_name_on_skillbar(&self.ecs, i as usize) {
                 battle_actions::select_skill(&mut self.ecs, &name);
             }
         }
@@ -80,7 +80,7 @@ impl BattleScene {
 
         // If they select a skill, start a new target session just like
         if let Some(i) = is_keystroke_skill(keycode) {
-            if let Some(name) = battle_actions::get_skill_name(&self.ecs, i as usize) {
+            if let Some(name) = super::views::get_skill_name_on_skillbar(&self.ecs, i as usize) {
                 battle_actions::select_skill(&mut self.ecs, &name);
             }
         }

--- a/src/arena/battle_scene.rs
+++ b/src/arena/battle_scene.rs
@@ -8,7 +8,7 @@ use specs::prelude::*;
 
 use super::components::*;
 use super::views::*;
-use super::{battle_actions, complete_animations, tick_animations};
+use super::{battle_actions, force_complete_animations, tick_animations};
 use crate::clash::*;
 
 use super::saveload;
@@ -204,7 +204,7 @@ impl Scene for BattleScene {
 
     fn on_quit(&mut self) -> BoxResult<()> {
         // Complete any outstanding animations to prevent any weirdness on load
-        complete_animations(&mut self.ecs);
+        force_complete_animations(&mut self.ecs);
 
         Ok(())
     }

--- a/src/arena/battle_scene.rs
+++ b/src/arena/battle_scene.rs
@@ -63,9 +63,9 @@ impl BattleScene {
             Keycode::Down => battle_actions::request_action(&mut self.ecs, super::BattleActionRequest::Move(Direction::South)),
             Keycode::Left => battle_actions::request_action(&mut self.ecs, super::BattleActionRequest::Move(Direction::West)),
             Keycode::Right => battle_actions::request_action(&mut self.ecs, super::BattleActionRequest::Move(Direction::East)),
-            Keycode::S => saveload::save(&mut self.ecs),
+            Keycode::S => saveload::save_to_disk(&mut self.ecs),
             Keycode::L => {
-                if let Ok(new_world) = saveload::load() {
+                if let Ok(new_world) = saveload::load_from_disk() {
                     self.ecs = new_world;
                 }
             }

--- a/src/arena/battle_scene.rs
+++ b/src/arena/battle_scene.rs
@@ -200,7 +200,10 @@ impl Scene for BattleScene {
         process_tick_events(&mut self.ecs, frame);
 
         if !battle_actions::has_animations_blocking(&self.ecs) {
-            tick_next_action(&mut self.ecs);
+            let player_can_act = tick_next_action(&mut self.ecs);
+            if player_can_act {
+                battle_actions::process_any_queued_action(&mut self.ecs);
+            }
         }
     }
 

--- a/src/arena/battle_scene.rs
+++ b/src/arena/battle_scene.rs
@@ -55,14 +55,14 @@ impl BattleScene {
 
         if let Some(i) = is_keystroke_skill(keycode) {
             if let Some(name) = super::views::get_skill_name_on_skillbar(&self.ecs, i as usize) {
-                battle_actions::select_skill(&mut self.ecs, &name);
+                battle_actions::request_action(&mut self.ecs, super::BattleActionRequest::SelectSkill(name.to_string()))
             }
         }
         match keycode {
-            Keycode::Up => battle_actions::move_action(&mut self.ecs, Direction::North),
-            Keycode::Down => battle_actions::move_action(&mut self.ecs, Direction::South),
-            Keycode::Left => battle_actions::move_action(&mut self.ecs, Direction::West),
-            Keycode::Right => battle_actions::move_action(&mut self.ecs, Direction::East),
+            Keycode::Up => battle_actions::request_action(&mut self.ecs, super::BattleActionRequest::Move(Direction::North)),
+            Keycode::Down => battle_actions::request_action(&mut self.ecs, super::BattleActionRequest::Move(Direction::South)),
+            Keycode::Left => battle_actions::request_action(&mut self.ecs, super::BattleActionRequest::Move(Direction::West)),
+            Keycode::Right => battle_actions::request_action(&mut self.ecs, super::BattleActionRequest::Move(Direction::East)),
             Keycode::S => saveload::save(&mut self.ecs),
             Keycode::L => {
                 if let Ok(new_world) = saveload::load() {
@@ -81,7 +81,7 @@ impl BattleScene {
         // If they select a skill, start a new target session just like
         if let Some(i) = is_keystroke_skill(keycode) {
             if let Some(name) = super::views::get_skill_name_on_skillbar(&self.ecs, i as usize) {
-                battle_actions::select_skill(&mut self.ecs, &name);
+                battle_actions::request_action(&mut self.ecs, super::BattleActionRequest::SelectSkill(name.to_string()));
             }
         }
     }
@@ -103,7 +103,7 @@ impl BattleScene {
         let hit = self.views.iter().filter_map(|v| v.hit_test(&self.ecs, x, y)).next();
         if button == MouseButton::Left {
             if let Some(HitTestResult::Skill(name)) = &hit {
-                battle_actions::select_skill(&mut self.ecs, &name)
+                battle_actions::request_action(&mut self.ecs, super::BattleActionRequest::SelectSkill(name.to_string()))
             }
         }
     }
@@ -123,7 +123,9 @@ impl BattleScene {
             if button == MouseButton::Left {
                 if let Some(map_position) = screen_to_map_position(x, y) {
                     match target_source {
-                        BattleTargetSource::Skill(skill_name) => battle_actions::select_skill_with_target(&mut self.ecs, &skill_name, &map_position),
+                        BattleTargetSource::Skill(skill_name) => {
+                            battle_actions::request_action(&mut self.ecs, super::BattleActionRequest::TargetSkill(skill_name.to_string(), map_position))
+                        }
                     }
                 }
             }

--- a/src/arena/battle_scene.rs
+++ b/src/arena/battle_scene.rs
@@ -55,7 +55,7 @@ impl BattleScene {
 
         if let Some(i) = is_keystroke_skill(keycode) {
             if let Some(name) = super::views::get_skill_name_on_skillbar(&self.ecs, i as usize) {
-                battle_actions::request_action(&mut self.ecs, super::BattleActionRequest::SelectSkill(name.to_string()))
+                battle_actions::request_action(&mut self.ecs, super::BattleActionRequest::SelectSkill(name))
             }
         }
         match keycode {
@@ -81,7 +81,7 @@ impl BattleScene {
         // If they select a skill, start a new target session just like
         if let Some(i) = is_keystroke_skill(keycode) {
             if let Some(name) = super::views::get_skill_name_on_skillbar(&self.ecs, i as usize) {
-                battle_actions::request_action(&mut self.ecs, super::BattleActionRequest::SelectSkill(name.to_string()));
+                battle_actions::request_action(&mut self.ecs, super::BattleActionRequest::SelectSkill(name));
             }
         }
     }
@@ -124,7 +124,7 @@ impl BattleScene {
                 if let Some(map_position) = screen_to_map_position(x, y) {
                     match target_source {
                         BattleTargetSource::Skill(skill_name) => {
-                            battle_actions::request_action(&mut self.ecs, super::BattleActionRequest::TargetSkill(skill_name.to_string(), map_position))
+                            battle_actions::request_action(&mut self.ecs, super::BattleActionRequest::TargetSkill(skill_name, map_position))
                         }
                     }
                 }

--- a/src/arena/components.rs
+++ b/src/arena/components.rs
@@ -10,6 +10,7 @@ mod render;
 pub use render::{RenderInfo, RenderOrder, SpriteKinds};
 
 use super::Animation;
+use super::BattleActionRequest;
 use crate::atlas::Point;
 use crate::clash::EventCoordinator;
 
@@ -82,6 +83,17 @@ impl RenderComponent {
     }
 }
 
+#[derive(Component)] // NotConvertSaveload
+pub struct BufferedInputComponent {
+    pub input: Option<BattleActionRequest>,
+}
+
+impl BufferedInputComponent {
+    pub fn init() -> BufferedInputComponent {
+        BufferedInputComponent { input: None }
+    }
+}
+
 pub fn add_ui_extension(ecs: &mut World) {
     ecs.register::<RenderComponent>();
     ecs.register::<BattleSceneStateComponent>();
@@ -99,6 +111,7 @@ pub fn add_ui_extension(ecs: &mut World) {
 
     ecs.insert(BattleSceneStateComponent::init());
     ecs.insert(MousePositionComponent::init());
+    ecs.insert(BufferedInputComponent::init());
 }
 
 pub trait UIState {

--- a/src/arena/components.rs
+++ b/src/arena/components.rs
@@ -94,6 +94,17 @@ impl BufferedInputComponent {
     }
 }
 
+#[derive(Component)] // NotConvertSaveload
+pub struct AccelerateAnimations {
+    pub state: bool,
+}
+
+impl AccelerateAnimations {
+    pub fn init() -> AccelerateAnimations {
+        AccelerateAnimations { state: false }
+    }
+}
+
 pub fn add_ui_extension(ecs: &mut World) {
     ecs.register::<RenderComponent>();
     ecs.register::<BattleSceneStateComponent>();
@@ -112,6 +123,7 @@ pub fn add_ui_extension(ecs: &mut World) {
     ecs.insert(BattleSceneStateComponent::init());
     ecs.insert(MousePositionComponent::init());
     ecs.insert(BufferedInputComponent::init());
+    ecs.insert(AccelerateAnimations::init());
 }
 
 pub trait UIState {

--- a/src/arena/saveload.rs
+++ b/src/arena/saveload.rs
@@ -110,6 +110,7 @@ pub fn save(ecs: &mut World) {
         FlightComponent,
         SkipRenderComponent,
         FieldCastComponent,
+        OrbWakeComponent,
         SerializationHelper
     );
 }

--- a/src/arena/saveload.rs
+++ b/src/arena/saveload.rs
@@ -1,5 +1,5 @@
 use std::fs::{read_to_string, File};
-use std::io::{Read, Write};
+use std::io::Write;
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
@@ -72,6 +72,7 @@ pub struct SerializationHelper {
     pub map: Map,
 }
 
+#[cfg(test)]
 pub fn save_to_string(ecs: &mut World) -> String {
     let mut writer = vec![];
     save(ecs, &mut writer);
@@ -134,6 +135,7 @@ pub fn load_from_disk() -> BoxResult<World> {
     load(data)
 }
 
+#[cfg(test)]
 pub fn load_from_string(data: String) -> BoxResult<World> {
     load(data)
 }

--- a/src/arena/saveload.rs
+++ b/src/arena/saveload.rs
@@ -110,7 +110,6 @@ pub fn save(ecs: &mut World) {
         FlightComponent,
         SkipRenderComponent,
         FieldCastComponent,
-        OrbWakeComponent,
         SerializationHelper
     );
 }

--- a/src/arena/saveload.rs
+++ b/src/arena/saveload.rs
@@ -1,4 +1,5 @@
 use std::fs::{read_to_string, File};
+use std::io::{Read, Write};
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
@@ -71,9 +72,23 @@ pub struct SerializationHelper {
     pub map: Map,
 }
 
-pub fn save(ecs: &mut World) {
-    let writer = File::create("./savegame.sav").unwrap();
-    let mut serializer = serde_json::Serializer::new(writer);
+pub fn save_to_string(ecs: &mut World) -> String {
+    let mut writer = vec![];
+    save(ecs, &mut writer);
+
+    let mut out = Vec::new();
+    let mut c = writer.as_slice();
+    c.read_to_end(&mut out).unwrap();
+    String::from_utf8(out).unwrap()
+}
+
+pub fn save_to_disk(ecs: &mut World) {
+    let mut writer = File::create("./savegame.sav").unwrap();
+    save(ecs, &mut writer);
+}
+
+fn save<T: Write>(ecs: &mut World, writer: &mut T) {
+    let mut serializer = serde_json::Serializer::new(&mut *writer);
 
     {
         let map = ecs.read_resource::<MapComponent>().map.clone();
@@ -89,9 +104,6 @@ pub fn save(ecs: &mut World) {
         serializer,
         data,
         PositionComponent,
-        RenderComponent,
-        BattleSceneStateComponent,
-        MousePositionComponent,
         FieldComponent,
         PlayerComponent,
         CharacterInfoComponent,
@@ -110,16 +122,27 @@ pub fn save(ecs: &mut World) {
         FlightComponent,
         SkipRenderComponent,
         FieldCastComponent,
+        RenderComponent,
+        BattleSceneStateComponent,
+        MousePositionComponent,
         SerializationHelper
     );
 }
 
-pub fn load() -> BoxResult<World> {
+pub fn load_from_disk() -> BoxResult<World> {
+    let data = read_to_string("./savegame.sav")?;
+    load(data)
+}
+
+pub fn load_from_string(data: String) -> BoxResult<World> {
+    load(data)
+}
+
+fn load(data: String) -> BoxResult<World> {
     let mut ecs = create_world();
     add_ui_extension(&mut ecs);
 
     {
-        let data = read_to_string("./savegame.sav")?;
         let mut de = serde_json::Deserializer::from_str(&data);
         let mut d = (
             &mut ecs.entities(),
@@ -132,9 +155,6 @@ pub fn load() -> BoxResult<World> {
             de,
             d,
             PositionComponent,
-            RenderComponent,
-            BattleSceneStateComponent,
-            MousePositionComponent,
             FieldComponent,
             PlayerComponent,
             CharacterInfoComponent,
@@ -153,6 +173,9 @@ pub fn load() -> BoxResult<World> {
             FlightComponent,
             SkipRenderComponent,
             FieldCastComponent,
+            RenderComponent,
+            BattleSceneStateComponent,
+            MousePositionComponent,
             SerializationHelper
         );
     }
@@ -168,4 +191,52 @@ pub fn load() -> BoxResult<World> {
     }
 
     Ok(ecs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::atlas::Point;
+
+    #[test]
+    fn save_load_smoke() {
+        let mut ecs = create_test_state().with_player(2, 2, 0).with_character(2, 6, 0).with_map().build();
+        let save = save_to_string(&mut ecs);
+        ecs = load_from_string(save).unwrap();
+        assert_eq!(2, find_all_characters(&ecs).len());
+    }
+
+    #[test]
+    fn save_load_with_field() {
+        let mut ecs = create_test_state().with_player(2, 2, 0).with_character(2, 6, 0).with_map().build();
+        let player = find_at(&ecs, 2, 2);
+
+        begin_field(&mut ecs, &player, Point::init(2, 6), FieldEffect::Damage(Damage::init(1)), FieldKind::Fire);
+        wait_for_animations(&mut ecs);
+
+        assert_field_exists(&ecs, 2, 6);
+
+        let save = save_to_string(&mut ecs);
+        ecs = load_from_string(save).unwrap();
+
+        assert_field_exists(&ecs, 2, 6);
+    }
+
+    #[test]
+    fn save_load_with_orbs() {
+        let mut ecs = create_test_state().with_player(2, 2, 0).with_character(2, 6, 0).with_map().build();
+        let player = find_at(&ecs, 2, 2);
+
+        begin_orb(&mut ecs, &player, Point::init(2, 6), Damage::init(2), OrbKind::Feather, 2, 12);
+        wait_for_animations(&mut ecs);
+
+        assert_field_exists(&ecs, 2, 4);
+        assert_field_count(&ecs, 5);
+
+        let save = save_to_string(&mut ecs);
+        ecs = load_from_string(save).unwrap();
+
+        assert_field_exists(&ecs, 2, 4);
+        assert_field_count(&ecs, 5);
+    }
 }

--- a/src/arena/saveload.rs
+++ b/src/arena/saveload.rs
@@ -1,4 +1,6 @@
 use std::fs::{read_to_string, File};
+#[cfg(test)]
+use std::io::Read;
 use std::io::Write;
 use std::path::Path;
 

--- a/src/arena/views.rs
+++ b/src/arena/views.rs
@@ -37,5 +37,5 @@ pub use debug::DebugView;
 pub use infobar::InfoBarView;
 pub use log::LogView;
 pub use map::{screen_rect_for_map_grid, screen_to_map_position, MapView, MAP_CORNER_Y, TILE_SIZE};
-pub use skillbar::{hotkey_to_skill_index, SkillBarView};
+pub use skillbar::{get_current_skill_on_skillbar, get_skill_name_on_skillbar, hotkey_to_skill_index, SkillBarView};
 pub use status_display::StatusBarView;

--- a/src/arena/views/debug.rs
+++ b/src/arena/views/debug.rs
@@ -28,7 +28,7 @@ impl DebugView {
 
 impl View for DebugView {
     fn render(&self, ecs: &World, canvas: &mut RenderCanvas, _frame: u64, _context: &ContextData) -> BoxResult<()> {
-        if let BattleSceneState::Debug(kind) = battle_actions::read_state(&ecs) {
+        if let BattleSceneState::Debug(kind) = battle_actions::read_action_state(&ecs) {
             let state = format!("Debug: {}", kind.to_string());
             self.text
                 .render_text(&state, self.position.x, self.position.y, canvas, FontSize::Small, FontColor::Red)?;

--- a/src/arena/views/map.rs
+++ b/src/arena/views/map.rs
@@ -233,7 +233,7 @@ pub fn screen_to_map_position(x: i32, y: i32) -> Option<Point> {
 }
 
 fn should_draw_grid(ecs: &World) -> bool {
-    let state = battle_actions::read_state(ecs);
+    let state = battle_actions::read_action_state(ecs);
     if state.is_targeting() {
         return true;
     }
@@ -247,7 +247,7 @@ fn should_draw_grid(ecs: &World) -> bool {
 }
 
 fn should_draw_cursor(ecs: &World) -> bool {
-    let state = battle_actions::read_state(ecs);
+    let state = battle_actions::read_action_state(ecs);
     match state {
         BattleSceneState::Targeting(_) => true,
         _ => false,
@@ -255,7 +255,7 @@ fn should_draw_cursor(ecs: &World) -> bool {
 }
 
 fn get_target_skill(ecs: &World) -> Option<&SkillInfo> {
-    let state = battle_actions::read_state(ecs);
+    let state = battle_actions::read_action_state(ecs);
     match state {
         BattleSceneState::Targeting(source) => match source {
             BattleTargetSource::Skill(name) => Some(get_skill(&name)),

--- a/src/arena/views/map.rs
+++ b/src/arena/views/map.rs
@@ -126,8 +126,14 @@ impl MapView {
 
         canvas.set_blend_mode(BlendMode::Blend);
         for (position, field) in (&positions, &fields).join() {
-            for position in position.position.all_positions().iter() {
-                self.draw_overlay_tile(canvas, position, Color::from(field.color))?;
+            for (p, (r, g, b, a)) in &field.fields {
+                if let Some(p) = p {
+                    self.draw_overlay_tile(canvas, p, Color::from((*r, *g, *b, *a)))?;
+                } else {
+                    for p in position.position.all_positions() {
+                        self.draw_overlay_tile(canvas, &p, Color::from((*r, *g, *b, *a)))?;
+                    }
+                }
             }
         }
 

--- a/src/arena/views/skillbar.rs
+++ b/src/arena/views/skillbar.rs
@@ -7,7 +7,6 @@ use sdl2::rect::Rect as SDLRect;
 use sdl2::render::Texture;
 use specs::prelude::*;
 
-use super::super::battle_actions;
 use super::{ContextData, HitTestResult, View};
 use crate::after_image::{FontColor, FontSize, IconCache, IconLoader, RenderCanvas, RenderContext, TextRenderer};
 use crate::atlas::{BoxResult, EasyECS};

--- a/src/clash/actions.rs
+++ b/src/clash/actions.rs
@@ -59,11 +59,17 @@ pub fn player_use_skill(ecs: &mut World, name: &str, target: Option<Point>) -> b
     true
 }
 
-pub fn tick_next_action(ecs: &mut World) {
+// Returns if player can act
+pub fn tick_next_action(ecs: &mut World) -> bool {
     if let Some(next) = wait_for_next(ecs) {
         if find_player(ecs) != next {
             take_enemy_action(ecs, &next);
+            false
+        } else {
+            true
         }
+    } else {
+        false
     }
 }
 

--- a/src/clash/actions.rs
+++ b/src/clash/actions.rs
@@ -24,7 +24,7 @@ pub fn find_enemies(ecs: &World) -> Vec<Entity> {
     enemies
 }
 
-fn can_act(ecs: &World) -> bool {
+pub fn can_act(ecs: &World) -> bool {
     let player = find_player(ecs);
     let is_player = if let Some(actor) = get_next_actor(ecs) { actor == player } else { false };
     let is_ready = get_ticks(ecs, &player) == BASE_ACTION_COST;

--- a/src/clash/combat.rs
+++ b/src/clash/combat.rs
@@ -501,10 +501,9 @@ mod tests {
 
         begin_orb(&mut ecs, &player, Point::init(2, 6), Damage::init(2), OrbKind::Feather, 2, 12);
         wait_for_animations(&mut ecs);
-        let orb = find_entity_at(&ecs, 2, 3);
 
         new_turn_wait_characters(&mut ecs);
-        assert_position(&ecs, &orb, Point::init(2, 5));
+        assert_orb_at_position(&ecs, Point::init(2, 5));
 
         new_turn_wait_characters(&mut ecs);
         assert!(ecs.get_defenses(&target).health < starting_health);
@@ -520,7 +519,7 @@ mod tests {
 
         begin_orb(&mut ecs, &player, Point::init(2, 6), Damage::init(2), OrbKind::Feather, 10, 12);
         wait_for_animations(&mut ecs);
-        find_entity_at(&ecs, 2, 3); // Crashes if not in expected positions
+        assert_orb_at_position(&ecs, Point::init(2, 3));
 
         new_turn_wait_characters(&mut ecs);
         assert!(ecs.get_defenses(&target).health < starting_health);
@@ -536,10 +535,9 @@ mod tests {
 
         begin_orb(&mut ecs, &player, Point::init(2, 6), Damage::init(2), OrbKind::Feather, 2, 12);
         wait_for_animations(&mut ecs);
-        let orb = find_entity_at(&ecs, 2, 3);
 
         new_turn_wait_characters(&mut ecs);
-        assert_position(&ecs, &orb, Point::init(2, 5));
+        assert_orb_at_position(&ecs, Point::init(2, 5));
 
         begin_move(&mut ecs, &target, SizedPoint::init(3, 6), PostMoveAction::None);
         wait_for_animations(&mut ecs);
@@ -564,10 +562,9 @@ mod tests {
 
         begin_orb(&mut ecs, &player, Point::init(2, 6), Damage::init(2), OrbKind::Feather, 2, 12);
         wait_for_animations(&mut ecs);
-        let orb = find_entity_at(&ecs, 2, 3);
 
         new_turn_wait_characters(&mut ecs);
-        assert_position(&ecs, &orb, Point::init(2, 5));
+        assert_orb_at_position(&ecs, Point::init(2, 5));
 
         begin_move(&mut ecs, &target, SizedPoint::init(1, 6), PostMoveAction::None);
         begin_move(&mut ecs, &bystander, SizedPoint::init(2, 6), PostMoveAction::None);
@@ -594,10 +591,9 @@ mod tests {
 
         begin_orb(&mut ecs, &player, Point::init(2, 7), Damage::init(2), OrbKind::Feather, 2, 12);
         wait_for_animations(&mut ecs);
-        let orb = find_entity_at(&ecs, 2, 3);
 
         new_turn_wait_characters(&mut ecs);
-        assert_position(&ecs, &orb, Point::init(2, 5));
+        assert_orb_at_position(&ecs, Point::init(2, 5));
 
         new_turn_wait_characters(&mut ecs);
         assert!(ecs.get_defenses(&bystander).health < bystander_starting_health);
@@ -620,10 +616,9 @@ mod tests {
 
         begin_orb(&mut ecs, &player, Point::init(2, 6), Damage::init(2), OrbKind::Feather, 2, 12);
         wait_for_animations(&mut ecs);
-        let orb = find_entity_at(&ecs, 2, 3);
 
         new_turn_wait_characters(&mut ecs);
-        assert_position(&ecs, &orb, Point::init(2, 5));
+        assert_orb_at_position(&ecs, Point::init(2, 5));
         begin_move(&mut ecs, &bystander, SizedPoint::init(2, 5), PostMoveAction::None);
         wait_for_animations(&mut ecs);
 

--- a/src/clash/combat.rs
+++ b/src/clash/combat.rs
@@ -492,6 +492,19 @@ mod tests {
         assert_eq!(ecs.get_defenses(&other).health, starting_health);
     }
 
+    pub fn assert_orb_at_position(ecs: &World, expected: Point) {
+        let orb_components = ecs.read_storage::<OrbComponent>();
+        let attack_components = ecs.read_storage::<AttackComponent>();
+        let position_components = ecs.read_storage::<PositionComponent>();
+
+        for (_, _, position) in (&orb_components, &attack_components, &position_components).join() {
+            if position.position.contains_point(&expected) {
+                return;
+            }
+        }
+        panic!("Unable to find orb at point {:?}");
+    }
+
     #[test]
     fn orb_hits_target_on_time() {
         let mut ecs = create_test_state().with_player(2, 2, 0).with_character(2, 6, 0).with_map().build();

--- a/src/clash/combat.rs
+++ b/src/clash/combat.rs
@@ -225,7 +225,7 @@ pub fn apply_field(ecs: &mut World, projectile: Entity) {
                 .with(PositionComponent::init(cast.target))
                 .with(AttackComponent::init(cast.target.origin, damage, AttackKind::Explode(0), None))
                 .with(BehaviorComponent::init(BehaviorKind::Explode))
-                .with(FieldComponent::init(r, g, b))
+                .with(FieldComponent::init_single(r, g, b))
                 .with(TimeComponent::init(-BASE_ACTION_COST))
                 .build();
         }

--- a/src/clash/components.rs
+++ b/src/clash/components.rs
@@ -69,16 +69,24 @@ impl FrameComponent {
     }
 }
 
+#[allow(clippy::type_complexity)]
+type SimpleColor = (u8, u8, u8, u8);
+
 #[derive(Component, ConvertSaveload, Clone)]
 pub struct FieldComponent {
-    #[allow(clippy::type_complexity)]
-    pub color: (u8, u8, u8, u8),
+    pub fields: Vec<(Option<Point>, SimpleColor)>,
 }
 
 #[allow(dead_code)]
 impl FieldComponent {
-    pub fn init(r: u8, g: u8, b: u8) -> FieldComponent {
-        FieldComponent { color: (r, g, b, 140) }
+    pub fn init() -> FieldComponent {
+        FieldComponent { fields: vec![] }
+    }
+
+    pub fn init_single(r: u8, g: u8, b: u8) -> FieldComponent {
+        FieldComponent {
+            fields: vec![(None, (r, g, b, 140))],
+        }
     }
 }
 

--- a/src/clash/content/spawner.rs
+++ b/src/clash/content/spawner.rs
@@ -1,7 +1,7 @@
 use specs::prelude::*;
 use specs::saveload::{MarkedBuilder, SimpleMarker};
 
-use crate::atlas::{SizedPoint, ToSerialize};
+use crate::atlas::{Point, SizedPoint, ToSerialize};
 use crate::clash::*;
 
 // All non-test create_entity() call should live here
@@ -59,4 +59,27 @@ pub fn bird_monster_add_egg(ecs: &mut World, position: SizedPoint) {
 
 pub fn bird_monster_add(ecs: &mut World, position: SizedPoint) {
     create_monster(ecs, "Bird", SpawnKind::BirdSpawn, BehaviorKind::BirdAdd, Defenses::just_health(40), position);
+}
+
+pub fn create_orb(ecs: &mut World, position: Point, attack: AttackComponent, orb: OrbComponent) -> Entity {
+    ecs.create_entity()
+        .with(PositionComponent::init(SizedPoint::from(position)))
+        .with(attack)
+        .with(orb)
+        .with(BehaviorComponent::init(BehaviorKind::Orb))
+        .with(TimeComponent::init(0))
+        .with(FieldComponent::init())
+        .marked::<SimpleMarker<ToSerialize>>()
+        .build()
+}
+
+pub fn create_damage_field(ecs: &mut World, position: SizedPoint, attack: AttackComponent, color: (u8, u8, u8)) -> Entity {
+    ecs.create_entity()
+        .with(PositionComponent::init(position))
+        .with(attack)
+        .with(BehaviorComponent::init(BehaviorKind::Explode))
+        .with(FieldComponent::init_single(color.0, color.1, color.2))
+        .with(TimeComponent::init(-BASE_ACTION_COST))
+        .marked::<SimpleMarker<ToSerialize>>()
+        .build()
 }

--- a/src/clash/map.rs
+++ b/src/clash/map.rs
@@ -94,7 +94,7 @@ mod tests {
         let mut ecs = create_test_state().with_player(2, 2, 0).with_character(3, 2, 0).build();
         ecs.create_entity()
             .with(PositionComponent::init(SizedPoint::init(4, 2)))
-            .with(FieldComponent::init(255, 0, 0))
+            .with(FieldComponent::init_single(255, 0, 0))
             .build();
 
         assert_eq!(MapHitTestResult::None(), element_at_location(&ecs, &Point::init(1, 2)));

--- a/src/clash/orb.rs
+++ b/src/clash/orb.rs
@@ -175,6 +175,15 @@ mod tests {
         assert_field_count(&ecs, 0);
     }
 
+    #[test]
+    fn orb_next_door() {
+        let mut ecs = create_test_state().with_player(2, 2, 0).with_character(2, 3, 0).with_map().build();
+        let player = find_at(&ecs, 2, 2);
+
+        begin_orb(&mut ecs, &player, Point::init(2, 3), Damage::init(2), OrbKind::Feather, 2, 12);
+        wait_for_animations(&mut ecs);
+    }
+
     // This test sets two bolts on the same path, with overlapping
     // fields showing the path. If they only check endpoint, one will blap another
     #[test]

--- a/src/clash/orb.rs
+++ b/src/clash/orb.rs
@@ -3,7 +3,7 @@ use std::cmp;
 use specs::prelude::*;
 
 use super::*;
-use crate::atlas::{EasyECS, SizedPoint};
+use crate::atlas::{EasyECS, EasyMutECS, SizedPoint};
 
 pub fn create_orb(ecs: &mut World, invoker: &Entity) -> Entity {
     let orb_component = ecs.read_storage::<OrbComponent>().grab(*invoker).clone();
@@ -12,24 +12,24 @@ pub fn create_orb(ecs: &mut World, invoker: &Entity) -> Entity {
     let path = &orb_component.path;
     let caster_position = ecs.get_position(invoker);
     let starting_index = path.iter().position(|x| !caster_position.contains_point(x)).unwrap();
+    let orb_position = path[starting_index];
 
-    add_orb_movement_fields(ecs, &orb_component, starting_index);
     let orb = ecs
         .create_entity()
-        .with(PositionComponent::init(SizedPoint::from(path[starting_index])))
+        .with(PositionComponent::init(SizedPoint::from(orb_position)))
         .with(attack_component)
         .with(orb_component)
         .with(BehaviorComponent::init(BehaviorKind::Orb))
         .with(TimeComponent::init(0))
+        .with(FieldComponent::init())
         .build();
+    add_orb_movement_fields(ecs, &orb, starting_index);
 
     orb
 }
 
 #[allow(clippy::needless_range_loop)]
 pub fn move_orb(ecs: &mut World, entity: &Entity) {
-    remove_stale_fields(ecs, entity);
-
     let orb = ecs.read_storage::<OrbComponent>().grab(*entity).clone();
     let current_position = ecs.get_position(entity).origin;
     let current_index = orb.path.iter().position(|&x| x == current_position).unwrap();
@@ -45,14 +45,17 @@ pub fn move_orb(ecs: &mut World, entity: &Entity) {
 
     if !at_end {
         wait(ecs, *entity);
-        add_orb_movement_fields(ecs, &orb, next_index);
+        add_orb_movement_fields(ecs, entity, next_index);
         begin_move(ecs, entity, SizedPoint::from(orb.path[next_index]), PostMoveAction::None);
     } else {
         ecs.delete_entity(*entity).unwrap();
     }
 }
 
-fn add_orb_movement_fields(ecs: &mut World, orb: &OrbComponent, current: usize) {
+fn add_orb_movement_fields(ecs: &mut World, entity: &Entity, current: usize) {
+    let mut fields_to_add = vec![];
+    let orbs = ecs.write_storage::<OrbComponent>();
+    let orb = orbs.grab(*entity);
     for i in 0..1 + (2 * orb.speed as usize) {
         let (r, g, b) = {
             if i < orb.speed as usize {
@@ -63,32 +66,14 @@ fn add_orb_movement_fields(ecs: &mut World, orb: &OrbComponent, current: usize) 
         };
 
         if let Some(field) = orb.path.get(current + i) {
-            ecs.create_entity()
-                .with(PositionComponent::init(SizedPoint::from(*field)))
-                .with(FieldComponent::init(r, g, b))
-                .with(orb.clone())
-                .build();
+            fields_to_add.push((Some(*field), (r, g, b)));
         }
     }
-}
-
-fn remove_stale_fields(ecs: &mut World, entity: &Entity) {
-    let mut stale = vec![];
-    {
-        let entities = ecs.read_resource::<specs::world::EntitiesRes>();
-        let positions = ecs.read_storage::<PositionComponent>();
-        let fields = ecs.read_storage::<FieldComponent>();
-        let orbs = ecs.read_storage::<OrbComponent>();
-        let last_point = &orbs.grab(*entity).path.last();
-        for (entity, _, orb, _) in (&entities, &positions, &orbs, &fields).join() {
-            if orb.path.last() == *last_point {
-                stale.push(entity);
-            }
-        }
-    }
-
-    for s in stale {
-        ecs.delete_entity(s).unwrap();
+    let mut fields = ecs.write_storage::<FieldComponent>();
+    let field_component = fields.grab_mut(*entity);
+    field_component.fields.clear();
+    for (p, (r, g, b)) in fields_to_add {
+        field_component.fields.push((p, (r, g, b, 140)));
     }
 }
 

--- a/src/clash/orb.rs
+++ b/src/clash/orb.rs
@@ -13,15 +13,7 @@ pub fn create_orb(ecs: &mut World, invoker: &Entity) -> Entity {
     let caster_position = ecs.get_position(invoker);
     let starting_index = path.iter().position(|x| !caster_position.contains_point(x)).unwrap();
 
-    let orb = ecs
-        .create_entity()
-        .with(PositionComponent::init(SizedPoint::from(path[starting_index])))
-        .with(attack_component)
-        .with(orb_component)
-        .with(BehaviorComponent::init(BehaviorKind::Orb))
-        .with(TimeComponent::init(0))
-        .with(FieldComponent::init())
-        .build();
+    let orb = super::content::spawner::create_orb(ecs, path[starting_index], attack_component, orb_component);
     add_orb_movement_fields(ecs, &orb, starting_index);
 
     orb
@@ -85,23 +77,6 @@ fn add_orb_movement_fields(ecs: &mut World, entity: &Entity, current: usize) {
 mod tests {
     use super::*;
     use crate::atlas::Point;
-
-    fn assert_field_exists(ecs: &World, x: u32, y: u32) {
-        let fields = ecs.read_storage::<FieldComponent>();
-        assert!((&fields).join().any(|f| f.fields.iter().any(|(p, _)| {
-            if let Some(p) = p {
-                p.x == x && p.y == y
-            } else {
-                false
-            }
-        })));
-    }
-
-    fn assert_field_count(ecs: &World, expected: usize) {
-        let fields = ecs.read_storage::<FieldComponent>();
-        let count: usize = (&fields).join().map(|f| f.fields.len()).sum();
-        assert_eq!(expected, count);
-    }
 
     #[test]
     fn orb_has_correct_fields() {

--- a/src/clash/orb.rs
+++ b/src/clash/orb.rs
@@ -84,13 +84,18 @@ mod tests {
 
     fn assert_field_exists(ecs: &World, x: u32, y: u32) {
         let fields = ecs.read_storage::<FieldComponent>();
-        let positions = ecs.read_storage::<PositionComponent>();
-        assert!((&fields, &positions).join().any(|(_, p)| p.position.origin.x == x && p.position.origin.y == y));
+        assert!((&fields).join().any(|f| f.fields.iter().any(|(p, _)| {
+            if let Some(p) = p {
+                p.x == x && p.y == y
+            } else {
+                false
+            }
+        })));
     }
 
     fn assert_field_count(ecs: &World, expected: usize) {
         let fields = ecs.read_storage::<FieldComponent>();
-        let count = (&fields).join().count();
+        let count: usize = (&fields).join().map(|f| f.fields.len()).sum();
         assert_eq!(expected, count);
     }
 
@@ -166,19 +171,6 @@ mod tests {
         assert_field_count(&ecs, 0);
     }
 
-    pub fn assert_orb_field_path_at_position(ecs: &World, expected: Point) {
-        let orb_components = ecs.read_storage::<OrbComponent>();
-        let fields = ecs.read_storage::<FieldComponent>();
-        let position_components = ecs.read_storage::<PositionComponent>();
-
-        for (_, _, position) in (&orb_components, &fields, &position_components).join() {
-            if position.position.contains_point(&expected) {
-                return;
-            }
-        }
-        panic!("Unable to find orb field (path) at point {:?}", expected);
-    }
-
     // This test sets two bolts on the same path, with overlapping
     // fields showing the path. If they only check endpoint, one will blap another
     #[test]
@@ -191,11 +183,11 @@ mod tests {
         dump_all_position(&ecs);
 
         // Bolt #1 at (2,3)
-        assert_orb_field_path_at_position(&ecs, Point::init(2, 3));
-        assert_orb_field_path_at_position(&ecs, Point::init(2, 4));
-        assert_orb_field_path_at_position(&ecs, Point::init(2, 5));
-        assert_orb_field_path_at_position(&ecs, Point::init(2, 6));
-        assert_orb_field_path_at_position(&ecs, Point::init(2, 7));
+        assert_field_exists(&ecs, 2, 3);
+        assert_field_exists(&ecs, 2, 4);
+        assert_field_exists(&ecs, 2, 5);
+        assert_field_exists(&ecs, 2, 6);
+        assert_field_exists(&ecs, 2, 7);
 
         // Bolt #1 to (2,5)
         new_turn_wait_characters(&mut ecs);
@@ -209,18 +201,18 @@ mod tests {
         dump_all_position(&ecs);
 
         // Bolt #1
-        assert_orb_field_path_at_position(&ecs, Point::init(2, 5));
-        assert_orb_field_path_at_position(&ecs, Point::init(2, 6));
-        assert_orb_field_path_at_position(&ecs, Point::init(2, 7));
-        assert_orb_field_path_at_position(&ecs, Point::init(2, 8));
-        assert_orb_field_path_at_position(&ecs, Point::init(2, 9));
+        assert_field_exists(&ecs, 2, 5);
+        assert_field_exists(&ecs, 2, 6);
+        assert_field_exists(&ecs, 2, 7);
+        assert_field_exists(&ecs, 2, 8);
+        assert_field_exists(&ecs, 2, 9);
 
         // Bolt #2
-        assert_orb_field_path_at_position(&ecs, Point::init(2, 3));
-        assert_orb_field_path_at_position(&ecs, Point::init(2, 4));
-        assert_orb_field_path_at_position(&ecs, Point::init(2, 5));
-        assert_orb_field_path_at_position(&ecs, Point::init(2, 6));
-        assert_orb_field_path_at_position(&ecs, Point::init(2, 7));
+        assert_field_exists(&ecs, 2, 3);
+        assert_field_exists(&ecs, 2, 4);
+        assert_field_exists(&ecs, 2, 5);
+        assert_field_exists(&ecs, 2, 6);
+        assert_field_exists(&ecs, 2, 7);
 
         dump_all_position(&ecs);
         new_turn_wait_characters(&mut ecs);
@@ -232,17 +224,17 @@ mod tests {
         // Bolt #2 at (2,5)
 
         // Bolt #1
-        assert_orb_field_path_at_position(&ecs, Point::init(2, 7));
-        assert_orb_field_path_at_position(&ecs, Point::init(2, 8));
-        assert_orb_field_path_at_position(&ecs, Point::init(2, 9));
-        assert_orb_field_path_at_position(&ecs, Point::init(2, 10));
-        assert_orb_field_path_at_position(&ecs, Point::init(2, 11));
+        assert_field_exists(&ecs, 2, 7);
+        assert_field_exists(&ecs, 2, 8);
+        assert_field_exists(&ecs, 2, 9);
+        assert_field_exists(&ecs, 2, 10);
+        assert_field_exists(&ecs, 2, 11);
 
         // Bolt #2
-        assert_orb_field_path_at_position(&ecs, Point::init(2, 5));
-        assert_orb_field_path_at_position(&ecs, Point::init(2, 6));
-        assert_orb_field_path_at_position(&ecs, Point::init(2, 7));
-        assert_orb_field_path_at_position(&ecs, Point::init(2, 8));
-        assert_orb_field_path_at_position(&ecs, Point::init(2, 9));
+        assert_field_exists(&ecs, 2, 5);
+        assert_field_exists(&ecs, 2, 6);
+        assert_field_exists(&ecs, 2, 7);
+        assert_field_exists(&ecs, 2, 8);
+        assert_field_exists(&ecs, 2, 9);
     }
 }

--- a/src/clash/orb.rs
+++ b/src/clash/orb.rs
@@ -53,7 +53,7 @@ pub fn move_orb(ecs: &mut World, entity: &Entity) {
 }
 
 fn add_orb_movement_fields(ecs: &mut World, orb: &OrbComponent, current: usize) {
-    for i in 0..2 * orb.speed as usize {
+    for i in 0..1 + (2 * orb.speed as usize) {
         let (r, g, b) = {
             if i < orb.speed as usize {
                 (255, 0, 0)
@@ -62,7 +62,7 @@ fn add_orb_movement_fields(ecs: &mut World, orb: &OrbComponent, current: usize) 
             }
         };
 
-        if let Some(field) = orb.path.get(current + i + 1) {
+        if let Some(field) = orb.path.get(current + i) {
             ecs.create_entity()
                 .with(PositionComponent::init(SizedPoint::from(*field)))
                 .with(FieldComponent::init(r, g, b))
@@ -119,7 +119,7 @@ mod tests {
         assert_field_exists(&ecs, 2, 4);
         assert_field_exists(&ecs, 2, 5);
         assert_field_exists(&ecs, 2, 6);
-        assert_field_count(&ecs, 4);
+        assert_field_count(&ecs, 5);
     }
 
     #[test]
@@ -132,7 +132,7 @@ mod tests {
         assert_field_exists(&ecs, 2, 4);
         assert_field_exists(&ecs, 2, 5);
         assert_field_exists(&ecs, 2, 6);
-        assert_field_count(&ecs, 9);
+        assert_field_count(&ecs, 10);
     }
 
     #[test]
@@ -148,7 +148,7 @@ mod tests {
         wait_for_animations(&mut ecs);
         assert_field_exists(&ecs, 2, 3);
         assert_field_exists(&ecs, 2, 2);
-        assert_field_count(&ecs, 4);
+        assert_field_count(&ecs, 5);
     }
 
     #[test]
@@ -171,12 +171,12 @@ mod tests {
         wait_for_animations(&mut ecs);
 
         for _ in 0..2 {
-            assert_field_count(&ecs, 4);
+            assert_field_count(&ecs, 5);
             new_turn_wait_characters(&mut ecs);
         }
-        assert_field_count(&ecs, 4);
+        assert_field_count(&ecs, 5);
         new_turn_wait_characters(&mut ecs);
-        assert_field_count(&ecs, 3);
+        assert_field_count(&ecs, 4);
         new_turn_wait_characters(&mut ecs);
         assert_field_count(&ecs, 0);
     }

--- a/src/clash/physics.rs
+++ b/src/clash/physics.rs
@@ -150,7 +150,7 @@ pub fn spend_focus(ecs: &mut World, invoker: &Entity, cost: f64) {
 
 #[cfg(test)]
 pub fn wait_for_animations(ecs: &mut World) {
-    crate::arena::complete_animations(ecs);
+    crate::arena::force_complete_animations(ecs);
 }
 
 pub fn find_clear_landing(ecs: &mut World, initial: &SizedPoint, entity: Option<Entity>) -> SizedPoint {

--- a/src/clash/physics.rs
+++ b/src/clash/physics.rs
@@ -210,7 +210,7 @@ mod tests {
         let entity = find_at(&ecs, 2, 2);
         ecs.create_entity()
             .with(PositionComponent::init(SizedPoint::init(2, 3)))
-            .with(FieldComponent::init(255, 0, 0))
+            .with(FieldComponent::init_single(255, 0, 0))
             .build();
 
         assert_position(&ecs, &entity, Point::init(2, 2));

--- a/src/clash/test_helpers.rs
+++ b/src/clash/test_helpers.rs
@@ -137,3 +137,11 @@ pub fn new_turn_wait_characters(ecs: &mut World) {
     tick_next_action(ecs);
     wait_for_animations(ecs);
 }
+
+pub fn dump_all_position(ecs: &World) {
+    let positions = ecs.read_storage::<PositionComponent>();
+    for position in (&positions).join() {
+        println!("{}", position.position);
+    }
+    println!("");
+}

--- a/src/clash/test_helpers.rs
+++ b/src/clash/test_helpers.rs
@@ -118,9 +118,24 @@ pub fn set_health(ecs: &mut World, player: Entity, health: u32) {
     ecs.write_storage::<CharacterInfoComponent>().grab_mut(player).character.defenses = Defenses::just_health(health);
 }
 
+// This can be dangerous, if something invalidates the entity reference
+// then you can crash here
 pub fn assert_position(ecs: &World, entity: &Entity, expected: Point) {
     let position = ecs.get_position(entity);
     assert_points_equal(position.single_position(), expected);
+}
+
+pub fn assert_orb_at_position(ecs: &World, expected: Point) {
+    let orb_components = ecs.read_storage::<OrbComponent>();
+    let attack_components = ecs.read_storage::<AttackComponent>();
+    let position_components = ecs.read_storage::<PositionComponent>();
+
+    for (_, _, position) in (&orb_components, &attack_components, &position_components).join() {
+        if position.position.contains_point(&expected) {
+            return;
+        }
+    }
+    panic!("Unable to find orb at point {:?}");
 }
 
 pub fn assert_not_at_position(ecs: &World, entity: &Entity, expected: Point) {
@@ -138,6 +153,7 @@ pub fn new_turn_wait_characters(ecs: &mut World) {
     wait_for_animations(ecs);
 }
 
+#[allow(dead_code)]
 pub fn dump_all_position(ecs: &World) {
     let positions = ecs.read_storage::<PositionComponent>();
     for position in (&positions).join() {

--- a/src/clash/test_helpers.rs
+++ b/src/clash/test_helpers.rs
@@ -144,8 +144,38 @@ pub fn new_turn_wait_characters(ecs: &mut World) {
 #[allow(dead_code)]
 pub fn dump_all_position(ecs: &World) {
     let positions = ecs.read_storage::<PositionComponent>();
-    for position in (&positions).join() {
-        println!("{}", position.position);
+    let char_infos = ecs.read_storage::<CharacterInfoComponent>();
+    let orb_components = ecs.read_storage::<OrbComponent>();
+    let attack_components = ecs.read_storage::<AttackComponent>();
+    let fields = ecs.read_storage::<FieldComponent>();
+    let times = ecs.read_storage::<TimeComponent>();
+    for (position, char_info, orb, attack, field, time) in (
+        &positions,
+        (&char_infos).maybe(),
+        (&orb_components).maybe(),
+        (&attack_components).maybe(),
+        (&fields).maybe(),
+        (&times).maybe(),
+    )
+        .join()
+    {
+        let mut description = format!("{}", position.position);
+        if char_info.is_some() {
+            description.push_str(" (Char)");
+        }
+        if orb.is_some() {
+            description.push_str(" (Orb)");
+        }
+        if attack.is_some() {
+            description.push_str(" (Attack)");
+        }
+        if field.is_some() {
+            description.push_str(" (Field)");
+        }
+        if time.is_some() {
+            description.push_str(format!(" ({})", time.unwrap().ticks).as_str());
+        }
+        println!("{}", description);
     }
     println!("");
 }

--- a/src/clash/test_helpers.rs
+++ b/src/clash/test_helpers.rs
@@ -48,6 +48,7 @@ pub fn find_at(ecs: &World, x: u32, y: u32) -> Entity {
     find_character_at_location(ecs, Point::init(x, y)).unwrap()
 }
 
+#[allow(dead_code)]
 pub fn find_entity_at(ecs: &World, x: u32, y: u32) -> Entity {
     find_entity_at_location(ecs, Point::init(x, y)).unwrap()
 }
@@ -123,19 +124,6 @@ pub fn set_health(ecs: &mut World, player: Entity, health: u32) {
 pub fn assert_position(ecs: &World, entity: &Entity, expected: Point) {
     let position = ecs.get_position(entity);
     assert_points_equal(position.single_position(), expected);
-}
-
-pub fn assert_orb_at_position(ecs: &World, expected: Point) {
-    let orb_components = ecs.read_storage::<OrbComponent>();
-    let attack_components = ecs.read_storage::<AttackComponent>();
-    let position_components = ecs.read_storage::<PositionComponent>();
-
-    for (_, _, position) in (&orb_components, &attack_components, &position_components).join() {
-        if position.position.contains_point(&expected) {
-            return;
-        }
-    }
-    panic!("Unable to find orb at point {:?}");
 }
 
 pub fn assert_not_at_position(ecs: &World, entity: &Entity, expected: Point) {


### PR DESCRIPTION
- Added input buffering (command inputted during animation applies when player can act).
- Added animation canceling (buffered input causes animations to play at 400% speed until it is your turn again. Speed subject to tweaking still.
- Extend orb path overlay to include orb itself
- Fix nasty issue where orb overlay was sometimes wrong when multiple orbs had same target square
- Fix completely broken save/load, specially with orbs. Add saveload tests