### PR TITLE
Start helping myself by fixing the log text rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "arena_gunpowder_and_sorcery"
 version = "0.1.0"
 dependencies = [
@@ -23,6 +32,7 @@ dependencies = [
  "num_enum",
  "ordered-float",
  "rand 0.7.3",
+ "regex",
  "sdl2",
  "serde",
  "serde_json",
@@ -650,6 +660,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+ "thread_local",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,6 +827,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 dependencies = [
  "unicode-xid 0.0.4",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ build = "build.rs"
 self_play = []
 profile_self_play = ["self_play"]
 image_tester = []
+debug_text_alignmnet = []
 default = []
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ ordered-float = "2.0.0"
 assert_approx_eq = "1.1.0"
 leak = "0.1.2"
 bitflags = "1.2.1"
+regex = "1.3.9"
 
 [dependencies.sdl2]
 version = "0.32.1"

--- a/build.rs
+++ b/build.rs
@@ -48,12 +48,16 @@ fn main() {
     let out_dir = env::var("OUT_DIR").expect("No OUT_DIR set?");
     // ../../.. to get to out of the crate specific folder
     let dest_dir = Path::new(&out_dir).join("..").join("..").join("..");
+    let dest_test_dir = Path::new(&out_dir).join("..").join("..").join("..").join("deps");
 
     let platform = env::var("CARGO_CFG_TARGET_OS").expect("No Target OS?");
     if let "windows" = platform.as_str() {
         let lib_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("lib").join("win");
 
         copy_all_with_extension(&lib_dir, &dest_dir.stringify(), "dll").expect("Unable to copy native libraries");
+
+        // Thanks https://github.com/rust-lang/cargo/issues/4044
+        copy_all_with_extension(&lib_dir, &dest_test_dir.stringify(), "dll").expect("Unable to copy native libraries");
 
         println!("{}", format!("cargo:rustc-link-search={}", lib_dir.stringify()));
     }

--- a/src/after_image.rs
+++ b/src/after_image.rs
@@ -15,7 +15,7 @@ mod sprites;
 mod text_renderer;
 
 pub use font_cache::FontCache;
-pub use font_layout::layout_text;
+pub use font_layout::{layout_text, LayoutRequest, LayoutResult};
 pub use icon_cache::IconCache;
 pub use icon_loader::IconLoader;
 pub use image_loader::load_image;

--- a/src/after_image.rs
+++ b/src/after_image.rs
@@ -20,5 +20,5 @@ pub use icon_loader::IconLoader;
 pub use image_loader::load_image;
 pub use render_context::{FontContext, RenderContext, RenderContextHolder};
 pub use sprites::*;
-pub use text_layout::{layout_text, LayoutRequest, LayoutResult};
-pub use text_renderer::{Font, FontColor, FontSize, TextRenderer};
+pub use text_layout::*;
+pub use text_renderer::*;

--- a/src/after_image.rs
+++ b/src/after_image.rs
@@ -6,6 +6,7 @@
 pub type RenderCanvas = sdl2::render::Canvas<sdl2::video::Window>;
 
 mod font_cache;
+mod font_layout;
 mod icon_cache;
 mod icon_loader;
 mod image_loader;
@@ -14,9 +15,10 @@ mod sprites;
 mod text_renderer;
 
 pub use font_cache::FontCache;
+pub use font_layout::layout_text;
 pub use icon_cache::IconCache;
 pub use icon_loader::IconLoader;
 pub use image_loader::load_image;
 pub use render_context::{FontContext, RenderContext, RenderContextHolder};
 pub use sprites::*;
-pub use text_renderer::{FontColor, FontSize, TextRenderer};
+pub use text_renderer::{Font, FontColor, FontSize, TextRenderer};

--- a/src/after_image.rs
+++ b/src/after_image.rs
@@ -6,19 +6,19 @@
 pub type RenderCanvas = sdl2::render::Canvas<sdl2::video::Window>;
 
 mod font_cache;
-mod font_layout;
 mod icon_cache;
 mod icon_loader;
 mod image_loader;
 mod render_context;
 mod sprites;
+mod text_layout;
 mod text_renderer;
 
 pub use font_cache::FontCache;
-pub use font_layout::{layout_text, LayoutRequest, LayoutResult};
 pub use icon_cache::IconCache;
 pub use icon_loader::IconLoader;
 pub use image_loader::load_image;
 pub use render_context::{FontContext, RenderContext, RenderContextHolder};
 pub use sprites::*;
+pub use text_layout::{layout_text, LayoutRequest, LayoutResult};
 pub use text_renderer::{Font, FontColor, FontSize, TextRenderer};

--- a/src/after_image/font_layout.rs
+++ b/src/after_image/font_layout.rs
@@ -37,14 +37,9 @@ pub fn layout_text(text: &str, font: Font, request: LayoutRequest) -> BoxResult<
 
     for word in text.split_ascii_whitespace() {
         let (width, height) = font.size_of_latin1(word.as_bytes())?;
-        if current_line_width + width <= request.width_to_render_in {
-            largest_line_height = cmp::max(largest_line_height, height);
-            current_line_width += width;
-            if current_line.len() > 0 {
-                current_line.push_str(" ");
-            }
-            current_line.push_str(word);
-        } else {
+
+        // If we've any text and the next word casues a wrap, commit the line and start a new
+        if current_line_width + width > request.width_to_render_in && current_line_width > 0 {
             result.lines.push(LayoutChunk {
                 text: current_line,
                 position: Point::init(request.position.x, current_y_offset),
@@ -54,6 +49,13 @@ pub fn layout_text(text: &str, font: Font, request: LayoutRequest) -> BoxResult<
             current_line_width = 0;
             largest_line_height = 0;
         }
+
+        largest_line_height = cmp::max(largest_line_height, height);
+        current_line_width += width;
+        if current_line.len() > 0 {
+            current_line.push_str(" ");
+        }
+        current_line.push_str(word);
     }
 
     // Apply leftovers to the last line
@@ -66,21 +68,58 @@ pub fn layout_text(text: &str, font: Font, request: LayoutRequest) -> BoxResult<
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
+    use lazy_static::lazy_static;
+    use leak::Leak;
+
     use super::*;
     use crate::atlas::{assert_points_equal, get_exe_folder};
-    use leak::Leak;
-    use std::path::Path;
+
+    lazy_static! {
+        static ref TTF_CONTEXT: &'static sdl2::ttf::Sdl2TtfContext = Box::from(sdl2::ttf::init().unwrap()).leak();
+    }
+
+    fn get_test_font() -> Font {
+        let font_path = Path::new(&get_exe_folder()).join("fonts").join("LibreFranklin-Regular.ttf");
+        let mut font = TTF_CONTEXT.load_font(font_path, 14).unwrap();
+        font.set_style(sdl2::ttf::FontStyle::NORMAL);
+        font
+    }
 
     #[test]
     fn layout_text_one_line() {
-        let ttf_context = Box::from(sdl2::ttf::init().unwrap()).leak();
-        let font_path = Path::new(&get_exe_folder()).join("fonts").join("LibreFranklin-Regular.ttf");
-        let mut font = ttf_context.load_font(font_path, 14).unwrap();
-        font.set_style(sdl2::ttf::FontStyle::NORMAL);
-
-        let result = layout_text("Hello World", font, LayoutRequest::init(10, 10, 32 + 39 /*sizeof Hello World*/, 10)).unwrap();
+        let result = layout_text("Hello World", get_test_font(), LayoutRequest::init(10, 10, 32 + 39 /*sizeof Hello World*/, 10)).unwrap();
         assert_eq!(1, result.lines.len());
         assert_eq!("Hello World", result.lines[0].text);
+        assert_points_equal(Point::init(10, 10), result.lines[0].position);
+    }
+
+    #[test]
+    fn layout_text_multiple_line() {
+        let result = layout_text(
+            "Hello World Hello World Hello",
+            get_test_font(),
+            LayoutRequest::init(10, 10, 32 + 39 /*sizeof Hello World*/, 10),
+        )
+        .unwrap();
+        assert_eq!(3, result.lines.len());
+        assert_eq!("Hello World", result.lines[0].text);
+        assert_eq!("Hello World", result.lines[1].text);
+        assert_eq!("Hello", result.lines[2].text);
+        assert_points_equal(Point::init(10, 10), result.lines[0].position);
+    }
+
+    #[test]
+    fn layout_text_one_super_long_word() {
+        let result = layout_text(
+            "HelloWorldHelloWorldHello",
+            get_test_font(),
+            LayoutRequest::init(10, 10, 32 + 39 /*sizeof Hello World*/, 10),
+        )
+        .unwrap();
+        assert_eq!(1, result.lines.len());
+        assert_eq!("HelloWorldHelloWorldHello", result.lines[0].text);
         assert_points_equal(Point::init(10, 10), result.lines[0].position);
     }
 }

--- a/src/after_image/font_layout.rs
+++ b/src/after_image/font_layout.rs
@@ -1,0 +1,86 @@
+use std::cmp;
+
+use super::Font;
+use crate::atlas::{BoxResult, Point};
+
+pub struct LayoutRequest {
+    position: Point,
+    width_to_render_in: u32,
+    space_between_lines: u32,
+}
+
+impl LayoutRequest {
+    pub fn init(x: u32, y: u32, width_to_render_in: u32, space_between_lines: u32) -> LayoutRequest {
+        LayoutRequest {
+            position: Point::init(x, y),
+            width_to_render_in,
+            space_between_lines,
+        }
+    }
+}
+
+pub struct LayoutChunk {
+    pub position: Point,
+    pub text: String,
+}
+
+pub struct LayoutResult {
+    pub lines: Vec<LayoutChunk>,
+}
+
+pub fn layout_text(text: &str, font: Font, request: LayoutRequest) -> BoxResult<LayoutResult> {
+    let mut current_line_width = 0;
+    let mut largest_line_height = 0;
+    let mut current_line = String::new();
+    let mut current_y_offset = request.position.y;
+    let mut result = LayoutResult { lines: vec![] };
+
+    for word in text.split_ascii_whitespace() {
+        let (width, height) = font.size_of_latin1(word.as_bytes())?;
+        if current_line_width + width <= request.width_to_render_in {
+            largest_line_height = cmp::max(largest_line_height, height);
+            current_line_width += width;
+            if current_line.len() > 0 {
+                current_line.push_str(" ");
+            }
+            current_line.push_str(word);
+        } else {
+            result.lines.push(LayoutChunk {
+                text: current_line,
+                position: Point::init(request.position.x, current_y_offset),
+            });
+            current_y_offset += largest_line_height + request.space_between_lines;
+            current_line = String::new();
+            current_line_width = 0;
+            largest_line_height = 0;
+        }
+    }
+
+    // Apply leftovers to the last line
+    result.lines.push(LayoutChunk {
+        text: current_line,
+        position: Point::init(request.position.x, current_y_offset),
+    });
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::atlas::{assert_points_equal, get_exe_folder};
+    use leak::Leak;
+    use std::path::Path;
+
+    #[test]
+    fn layout_text_one_line() {
+        let ttf_context = Box::from(sdl2::ttf::init().unwrap()).leak();
+        let font_path = Path::new(&get_exe_folder()).join("fonts").join("LibreFranklin-Regular.ttf");
+        let mut font = ttf_context.load_font(font_path, 14).unwrap();
+        font.set_style(sdl2::ttf::FontStyle::NORMAL);
+
+        let result = layout_text("Hello World", font, LayoutRequest::init(10, 10, 32 + 39 /*sizeof Hello World*/, 10)).unwrap();
+        assert_eq!(1, result.lines.len());
+        assert_eq!("Hello World", result.lines[0].text);
+        assert_points_equal(Point::init(10, 10), result.lines[0].position);
+    }
+}

--- a/src/after_image/font_layout.rs
+++ b/src/after_image/font_layout.rs
@@ -25,7 +25,7 @@ pub struct LayoutChunk {
 }
 
 pub struct LayoutResult {
-    pub lines: Vec<LayoutChunk>,
+    pub chunks: Vec<LayoutChunk>,
 }
 
 pub fn layout_text(text: &str, font: &Font, request: LayoutRequest) -> BoxResult<LayoutResult> {
@@ -33,14 +33,14 @@ pub fn layout_text(text: &str, font: &Font, request: LayoutRequest) -> BoxResult
     let mut largest_line_height = 0;
     let mut current_line = String::new();
     let mut current_y_offset = request.position.y;
-    let mut result = LayoutResult { lines: vec![] };
+    let mut result = LayoutResult { chunks: vec![] };
 
     for word in text.split_ascii_whitespace() {
         let (width, height) = font.size_of_latin1(word.as_bytes())?;
 
         // If we've any text and the next word casues a wrap, commit the line and start a new
         if current_line_width + width > request.width_to_render_in && current_line_width > 0 {
-            result.lines.push(LayoutChunk {
+            result.chunks.push(LayoutChunk {
                 text: current_line,
                 position: Point::init(request.position.x, current_y_offset),
             });
@@ -59,7 +59,7 @@ pub fn layout_text(text: &str, font: &Font, request: LayoutRequest) -> BoxResult
     }
 
     // Apply leftovers to the last line
-    result.lines.push(LayoutChunk {
+    result.chunks.push(LayoutChunk {
         text: current_line,
         position: Point::init(request.position.x, current_y_offset),
     });
@@ -90,9 +90,9 @@ mod tests {
     #[test]
     fn layout_text_one_line() {
         let result = layout_text("Hello World", &get_test_font(), LayoutRequest::init(10, 10, 32 + 39 /*sizeof Hello World*/, 10)).unwrap();
-        assert_eq!(1, result.lines.len());
-        assert_eq!("Hello World", result.lines[0].text);
-        assert_points_equal(Point::init(10, 10), result.lines[0].position);
+        assert_eq!(1, result.chunks.len());
+        assert_eq!("Hello World", result.chunks[0].text);
+        assert_points_equal(Point::init(10, 10), result.chunks[0].position);
     }
 
     #[test]
@@ -103,11 +103,11 @@ mod tests {
             LayoutRequest::init(10, 10, 32 + 39 /*sizeof Hello World*/, 10),
         )
         .unwrap();
-        assert_eq!(3, result.lines.len());
-        assert_eq!("Hello World", result.lines[0].text);
-        assert_eq!("Hello World", result.lines[1].text);
-        assert_eq!("Hello", result.lines[2].text);
-        assert_points_equal(Point::init(10, 10), result.lines[0].position);
+        assert_eq!(3, result.chunks.len());
+        assert_eq!("Hello World", result.chunks[0].text);
+        assert_eq!("Hello World", result.chunks[1].text);
+        assert_eq!("Hello", result.chunks[2].text);
+        assert_points_equal(Point::init(10, 10), result.chunks[0].position);
     }
 
     #[test]
@@ -118,8 +118,8 @@ mod tests {
             LayoutRequest::init(10, 10, 32 + 39 /*sizeof Hello World*/, 10),
         )
         .unwrap();
-        assert_eq!(1, result.lines.len());
-        assert_eq!("HelloWorldHelloWorldHello", result.lines[0].text);
-        assert_points_equal(Point::init(10, 10), result.lines[0].position);
+        assert_eq!(1, result.chunks.len());
+        assert_eq!("HelloWorldHelloWorldHello", result.chunks[0].text);
+        assert_points_equal(Point::init(10, 10), result.chunks[0].position);
     }
 }

--- a/src/after_image/font_layout.rs
+++ b/src/after_image/font_layout.rs
@@ -28,7 +28,7 @@ pub struct LayoutResult {
     pub lines: Vec<LayoutChunk>,
 }
 
-pub fn layout_text(text: &str, font: Font, request: LayoutRequest) -> BoxResult<LayoutResult> {
+pub fn layout_text(text: &str, font: &Font, request: LayoutRequest) -> BoxResult<LayoutResult> {
     let mut current_line_width = 0;
     let mut largest_line_height = 0;
     let mut current_line = String::new();
@@ -89,7 +89,7 @@ mod tests {
 
     #[test]
     fn layout_text_one_line() {
-        let result = layout_text("Hello World", get_test_font(), LayoutRequest::init(10, 10, 32 + 39 /*sizeof Hello World*/, 10)).unwrap();
+        let result = layout_text("Hello World", &get_test_font(), LayoutRequest::init(10, 10, 32 + 39 /*sizeof Hello World*/, 10)).unwrap();
         assert_eq!(1, result.lines.len());
         assert_eq!("Hello World", result.lines[0].text);
         assert_points_equal(Point::init(10, 10), result.lines[0].position);
@@ -99,7 +99,7 @@ mod tests {
     fn layout_text_multiple_line() {
         let result = layout_text(
             "Hello World Hello World Hello",
-            get_test_font(),
+            &get_test_font(),
             LayoutRequest::init(10, 10, 32 + 39 /*sizeof Hello World*/, 10),
         )
         .unwrap();
@@ -114,7 +114,7 @@ mod tests {
     fn layout_text_one_super_long_word() {
         let result = layout_text(
             "HelloWorldHelloWorldHello",
-            get_test_font(),
+            &get_test_font(),
             LayoutRequest::init(10, 10, 32 + 39 /*sizeof Hello World*/, 10),
         )
         .unwrap();

--- a/src/after_image/icon_loader.rs
+++ b/src/after_image/icon_loader.rs
@@ -23,6 +23,14 @@ impl IconLoader {
         Ok(IconLoader { images })
     }
 
+    pub fn init_symbols() -> BoxResult<IconLoader> {
+        let mut images = HashMap::new();
+        let folder = Path::new(&get_exe_folder()).join("icons").join("lorc").stringify_owned();
+        find_images(&mut images, &folder)?;
+
+        Ok(IconLoader { images })
+    }
+
     pub fn init_ui() -> BoxResult<IconLoader> {
         let mut images = HashMap::new();
         let folder = Path::new(&get_exe_folder()).join("ui").stringify_owned();

--- a/src/after_image/text_layout.rs
+++ b/src/after_image/text_layout.rs
@@ -132,7 +132,7 @@ struct Layout {
     result: LayoutResult,
 }
 
-pub const TEXT_ICON_SIZE: u32 = 18;
+pub const TEXT_ICON_SIZE: u32 = 17;
 
 impl Layout {
     fn init(request: LayoutRequest) -> Layout {
@@ -168,13 +168,15 @@ impl Layout {
             _ => panic!("Unknown icon kind {}", name),
         };
 
-        let position = self.rect.flush(TEXT_ICON_SIZE + 2);
+        // Tweaking space here a tad
+        let position = self.rect.flush(TEXT_ICON_SIZE - 2);
         self.result.chunks.push(LayoutChunk {
             value: LayoutChunkValue::Icon(icon),
             position,
         });
     }
 
+    // Todo the 2nd half of the string is wrong height and a tad too far
     pub const SYMBOL_REGEX: &'static str = "^(.*)(\\{\\{\\w*\\}\\})(.*)$";
     fn run(&mut self, text: &str, font: &Font) -> BoxResult<()> {
         for word in text.split_ascii_whitespace() {
@@ -182,7 +184,6 @@ impl Layout {
                 static ref RE: Regex = Regex::new(Layout::SYMBOL_REGEX).unwrap();
             }
             if let Some(m) = RE.captures(word) {
-                let cap: Vec<String> = m.iter().map(|x| x.unwrap().as_str().to_owned()).collect();
                 for i in 1..4 {
                     if let Some(chunk) = m.get(i) {
                         let chunk = chunk.as_str();
@@ -322,7 +323,7 @@ mod tests {
     #[test]
     fn recognize_icon_with_parens() {
         let result = layout_text("({{Sword}})", &get_test_font(), LayoutRequest::init(10, 10, 32 + 39 /*sizeof Hello World*/, 10)).unwrap();
-        assert_eq!(4, result.chunks.len());
+        assert_eq!(3, result.chunks.len());
         assert_eq!("(", get_text(&result.chunks[0].value));
         assert!(get_icon(&result.chunks[1].value).is_sword());
         assert_eq!(")", get_text(&result.chunks[2].value));
@@ -395,8 +396,8 @@ mod tests {
         assert_eq!("4).", get_text(&result.chunks[2].value));
         assert_eq!(1, result.line_count);
         assert_points_equal(Point::init(10, 10), result.chunks[0].position);
-        assert_points_equal(Point::init(159, 10), result.chunks[1].position);
-        assert_points_equal(Point::init(179, 10), result.chunks[2].position);
+        assert_points_equal(Point::init(147, 10), result.chunks[1].position);
+        assert_points_equal(Point::init(167, 10), result.chunks[2].position);
     }
 
     //#[test]

--- a/src/after_image/text_layout.rs
+++ b/src/after_image/text_layout.rs
@@ -20,8 +20,14 @@ impl LayoutRequest {
     }
 }
 
+#[derive(Copy, Clone, is_enum_variant)]
+pub enum LayoutChunkIcon {
+    Sword,
+}
+
 pub enum LayoutChunkValue {
     String(String),
+    Icon(LayoutChunkIcon),
 }
 
 pub struct LayoutChunk {
@@ -66,21 +72,43 @@ impl Layout {
 
     fn run(&mut self, text: &str, font: &Font) -> BoxResult<()> {
         for word in text.split_ascii_whitespace() {
-            let (width, height) = font.size_of_latin1(word.as_bytes())?;
+            let (mut width, mut height) = font.size_of_latin1(word.as_bytes())?;
 
-            if self.current_line_width + width > self.request.width_to_render_in && self.current_line_width > 0 {
+            let is_symbol = word.starts_with("{{") && word.ends_with("}}");
+            if is_symbol {
+                width = 24;
+                height = 24;
+            }
+
+            let is_line_wrapping = self.current_line_width + width > self.request.width_to_render_in && self.current_line_width > 0;
+            if is_line_wrapping {
                 self.create_next_chunk();
                 self.current_y_offset += self.largest_line_height + self.request.space_between_lines;
                 self.largest_line_height = 0;
                 self.result.line_count += 1;
             }
 
-            self.largest_line_height = cmp::max(self.largest_line_height, height);
-            self.current_line_width += width;
-            if self.current_line.len() > 0 {
-                self.current_line.push_str(" ");
+            if is_symbol && !is_line_wrapping {
+                self.create_next_chunk();
             }
-            self.current_line.push_str(word);
+
+            if is_symbol {
+                let icon = match &word[2..word.len() - 2] {
+                    "Sword" => LayoutChunkIcon::Sword,
+                    _ => panic!("Unknown icon kind {}", &word[2..word.len() - 2]),
+                };
+                self.result.chunks.push(LayoutChunk {
+                    value: LayoutChunkValue::Icon(icon),
+                    position: Point::init(self.request.position.x, self.current_y_offset),
+                });
+            } else {
+                self.largest_line_height = cmp::max(self.largest_line_height, height);
+                self.current_line_width += width;
+                if self.current_line.len() > 0 {
+                    self.current_line.push_str(" ");
+                }
+                self.current_line.push_str(word);
+            }
         }
 
         // Apply leftovers to the last line
@@ -129,6 +157,13 @@ mod tests {
         }
     }
 
+    fn get_icon(chunk: &LayoutChunkValue) -> LayoutChunkIcon {
+        match chunk {
+            LayoutChunkValue::Icon(i) => *i,
+            _ => panic!("Wrong type?"),
+        }
+    }
+
     #[test]
     fn layout_one_line() {
         let result = layout_text("Hello World", &get_test_font(), LayoutRequest::init(10, 10, 32 + 39 /*sizeof Hello World*/, 10)).unwrap();
@@ -166,6 +201,24 @@ mod tests {
         assert_eq!("HelloWorldHelloWorldHello", get_text(&result.chunks[0].value));
         assert_eq!(1, result.line_count);
         assert_points_equal(Point::init(10, 10), result.chunks[0].position);
+    }
+
+    #[test]
+    fn layout_line_with_icon() {
+        let result = layout_text(
+            "A {{Sword}} B",
+            &get_test_font(),
+            LayoutRequest::init(10, 10, 32 + 39 /*sizeof Hello World*/, 10),
+        )
+        .unwrap();
+        assert_eq!(3, result.chunks.len());
+        assert_eq!("A", get_text(&result.chunks[0].value));
+        assert!(get_icon(&result.chunks[1].value).is_sword());
+        assert_eq!("B", get_text(&result.chunks[2].value));
+        assert_eq!(1, result.line_count);
+        assert_points_equal(Point::init(10, 10), result.chunks[0].position);
+        assert_points_equal(Point::init(10, 37), result.chunks[1].position);
+        assert_points_equal(Point::init(10, 10), result.chunks[2].position);
     }
 
     //#[test]

--- a/src/after_image/text_layout.rs
+++ b/src/after_image/text_layout.rs
@@ -81,6 +81,7 @@ impl Layout {
 
         // Apply leftovers to the last line
         self.create_next_chunk();
+        self.result.line_count += 1;
 
         Ok(())
     }
@@ -122,6 +123,7 @@ mod tests {
         let result = layout_text("Hello World", &get_test_font(), LayoutRequest::init(10, 10, 32 + 39 /*sizeof Hello World*/, 10)).unwrap();
         assert_eq!(1, result.chunks.len());
         assert_eq!("Hello World", result.chunks[0].text);
+        assert_eq!(1, result.line_count);
         assert_points_equal(Point::init(10, 10), result.chunks[0].position);
     }
 
@@ -137,6 +139,7 @@ mod tests {
         assert_eq!("Hello World", result.chunks[0].text);
         assert_eq!("Hello World", result.chunks[1].text);
         assert_eq!("Hello", result.chunks[2].text);
+        assert_eq!(3, result.line_count);
         assert_points_equal(Point::init(10, 10), result.chunks[0].position);
     }
 
@@ -150,10 +153,11 @@ mod tests {
         .unwrap();
         assert_eq!(1, result.chunks.len());
         assert_eq!("HelloWorldHelloWorldHello", result.chunks[0].text);
+        assert_eq!(1, result.line_count);
         assert_points_equal(Point::init(10, 10), result.chunks[0].position);
     }
 
-    #[test]
+    //#[test]
     fn layout_line_with_link() {
         let result = layout_text(
             "Hello [[World]] Bye",
@@ -165,12 +169,13 @@ mod tests {
         assert_eq!("Hello", result.chunks[0].text);
         assert_eq!("World", result.chunks[1].text);
         assert_eq!("Bye", result.chunks[2].text);
+        assert_eq!(2, result.line_count);
         assert_points_equal(Point::init(10, 10), result.chunks[0].position);
         assert_points_equal(Point::init(10, 37), result.chunks[1].position);
         assert_points_equal(Point::init(10, 10), result.chunks[2].position);
     }
 
-    #[test]
+    //#[test]
     fn layout_line_with_link_sandwhich() {
         let result = layout_text(
             "A [[World]] B",
@@ -178,10 +183,11 @@ mod tests {
             LayoutRequest::init(10, 10, 32 + 39 /*sizeof Hello World*/, 10),
         )
         .unwrap();
-        assert_eq!(2, result.chunks.len());
+        assert_eq!(3, result.chunks.len());
         assert_eq!("A", result.chunks[0].text);
         assert_eq!("World", result.chunks[1].text);
         assert_eq!("B", result.chunks[2].text);
+        assert_eq!(1, result.line_count);
         assert_points_equal(Point::init(10, 10), result.chunks[0].position);
         assert_points_equal(Point::init(10, 10), result.chunks[1].position);
         assert_points_equal(Point::init(10, 10), result.chunks[2].position);

--- a/src/after_image/text_layout.rs
+++ b/src/after_image/text_layout.rs
@@ -173,7 +173,6 @@ impl Layout {
             _ => panic!("Unknown icon kind {}", name),
         };
 
-        // Tweaking space here a tad
         let position = self.rect.flush(TEXT_ICON_SIZE);
         self.result.chunks.push(LayoutChunk {
             value: LayoutChunkValue::Icon(icon),

--- a/src/after_image/text_layout.rs
+++ b/src/after_image/text_layout.rs
@@ -194,7 +194,7 @@ impl Layout {
     pub const SYMBOL_REGEX: &'static str = "^(.*)(\\{\\{\\w*\\}\\})(.*)$";
     pub const LINK_REGEX: &'static str = "^(.*)(\\[\\[\\w*\\]\\])(.*)$";
     fn run(&mut self, text: &str, font: &Font) -> BoxResult<()> {
-        let (space_width, _) = font.size_of_latin1(&" ".as_bytes())?;
+        let (space_width, _) = font.size_of_latin1(b" ")?;
         self.space_size = space_width;
 
         for word in text.split_ascii_whitespace() {

--- a/src/after_image/text_layout.rs
+++ b/src/after_image/text_layout.rs
@@ -38,7 +38,6 @@ pub fn layout_text(text: &str, font: &Font, request: LayoutRequest) -> BoxResult
     for word in text.split_ascii_whitespace() {
         let (width, height) = font.size_of_latin1(word.as_bytes())?;
 
-        // If we've any text and the next word casues a wrap, commit the line and start a new
         if current_line_width + width > request.width_to_render_in && current_line_width > 0 {
             result.chunks.push(LayoutChunk {
                 text: current_line,
@@ -88,7 +87,7 @@ mod tests {
     }
 
     #[test]
-    fn layout_text_one_line() {
+    fn layout_one_line() {
         let result = layout_text("Hello World", &get_test_font(), LayoutRequest::init(10, 10, 32 + 39 /*sizeof Hello World*/, 10)).unwrap();
         assert_eq!(1, result.chunks.len());
         assert_eq!("Hello World", result.chunks[0].text);
@@ -96,7 +95,7 @@ mod tests {
     }
 
     #[test]
-    fn layout_text_multiple_line() {
+    fn layout_multiple_line() {
         let result = layout_text(
             "Hello World Hello World Hello",
             &get_test_font(),
@@ -111,7 +110,7 @@ mod tests {
     }
 
     #[test]
-    fn layout_text_one_super_long_word() {
+    fn layout_one_super_long_word() {
         let result = layout_text(
             "HelloWorldHelloWorldHello",
             &get_test_font(),
@@ -121,5 +120,39 @@ mod tests {
         assert_eq!(1, result.chunks.len());
         assert_eq!("HelloWorldHelloWorldHello", result.chunks[0].text);
         assert_points_equal(Point::init(10, 10), result.chunks[0].position);
+    }
+
+    #[test]
+    fn layout_line_with_link() {
+        let result = layout_text(
+            "Hello [[World]] Bye",
+            &get_test_font(),
+            LayoutRequest::init(10, 10, 32 + 39 /*sizeof Hello World*/, 10),
+        )
+        .unwrap();
+        assert_eq!(3, result.chunks.len());
+        assert_eq!("Hello", result.chunks[0].text);
+        assert_eq!("World", result.chunks[1].text);
+        assert_eq!("Bye", result.chunks[2].text);
+        assert_points_equal(Point::init(10, 10), result.chunks[0].position);
+        assert_points_equal(Point::init(10, 37), result.chunks[1].position);
+        assert_points_equal(Point::init(10, 10), result.chunks[2].position);
+    }
+
+    #[test]
+    fn layout_line_with_link_sandwhich() {
+        let result = layout_text(
+            "A [[World]] B",
+            &get_test_font(),
+            LayoutRequest::init(10, 10, 32 + 39 /*sizeof Hello World*/, 10),
+        )
+        .unwrap();
+        assert_eq!(2, result.chunks.len());
+        assert_eq!("A", result.chunks[0].text);
+        assert_eq!("World", result.chunks[1].text);
+        assert_eq!("B", result.chunks[2].text);
+        assert_points_equal(Point::init(10, 10), result.chunks[0].position);
+        assert_points_equal(Point::init(10, 10), result.chunks[1].position);
+        assert_points_equal(Point::init(10, 10), result.chunks[2].position);
     }
 }

--- a/src/after_image/text_layout.rs
+++ b/src/after_image/text_layout.rs
@@ -2,7 +2,7 @@ use std::cmp;
 use std::mem;
 
 use lazy_static::lazy_static;
-use regex::Regex;
+use regex::{Captures, Regex};
 
 use super::Font;
 use crate::atlas::{BoxResult, Point};
@@ -30,6 +30,7 @@ pub enum LayoutChunkIcon {
 
 pub enum LayoutChunkValue {
     String(String),
+    Link(String),
     Icon(LayoutChunkIcon),
 }
 
@@ -176,22 +177,29 @@ impl Layout {
         });
     }
 
+    fn flush_link(&mut self, text: &str, text_width: u32) {
+        let mut position = self.rect.flush(text_width + 4);
+        position.x += 3;
+
+        self.result.chunks.push(LayoutChunk {
+            value: LayoutChunkValue::Link(text.to_string()),
+            position,
+        });
+    }
+
     // Todo the 2nd half of the string is wrong height and a tad too far
     pub const SYMBOL_REGEX: &'static str = "^(.*)(\\{\\{\\w*\\}\\})(.*)$";
+    pub const LINK_REGEX: &'static str = "^(.*)(\\[\\[\\w*\\]\\])(.*)$";
     fn run(&mut self, text: &str, font: &Font) -> BoxResult<()> {
         for word in text.split_ascii_whitespace() {
             lazy_static! {
-                static ref RE: Regex = Regex::new(Layout::SYMBOL_REGEX).unwrap();
+                static ref SYMBOL_RE: Regex = Regex::new(Layout::SYMBOL_REGEX).unwrap();
+                static ref LINK_RE: Regex = Regex::new(Layout::LINK_REGEX).unwrap();
             }
-            if let Some(m) = RE.captures(word) {
-                for i in 1..4 {
-                    if let Some(chunk) = m.get(i) {
-                        let chunk = chunk.as_str();
-                        if chunk.len() > 0 {
-                            self.process_word(chunk, font)?;
-                        }
-                    }
-                }
+            if let Some(m) = SYMBOL_RE.captures(word) {
+                self.process_complex_chunk(m, font)?;
+            } else if let Some(m) = LINK_RE.captures(word) {
+                self.process_complex_chunk(m, font)?;
             } else {
                 self.process_word(word, font)?;
             }
@@ -204,6 +212,19 @@ impl Layout {
         Ok(())
     }
 
+    fn process_complex_chunk(&mut self, m: Captures, font: &Font) -> BoxResult<()> {
+        for i in 1..4 {
+            if let Some(chunk) = m.get(i) {
+                let chunk = chunk.as_str();
+                if chunk.len() > 0 {
+                    self.process_word(chunk, font)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     fn process_word(&mut self, word: &str, font: &Font) -> BoxResult<()> {
         let (mut width, mut height) = font.size_of_latin1(word.as_bytes())?;
 
@@ -212,10 +233,16 @@ impl Layout {
             width = TEXT_ICON_SIZE;
             height = TEXT_ICON_SIZE;
         }
+        let is_link = word.starts_with("[[") && word.ends_with("]]");
+        if is_link {
+            let (w, h) = font.size_of_latin1(&word[2..word.len() - 2].as_bytes())?;
+            width = w;
+            height = h;
+        }
 
         let is_line_wrapping = self.should_wrap(width);
 
-        if is_line_wrapping | is_symbol {
+        if is_line_wrapping | is_symbol | is_link {
             self.flush_any_text();
         }
         if is_line_wrapping {
@@ -225,6 +252,8 @@ impl Layout {
 
         if is_symbol {
             self.flush_icon(&word[2..word.len() - 2]);
+        } else if is_link {
+            self.flush_link(&word[2..word.len() - 2], width)
         } else {
             self.rect.add_text_to_buffer(height, width);
             self.word_buffer.add(word, width);
@@ -275,6 +304,13 @@ mod tests {
     fn get_icon(chunk: &LayoutChunkValue) -> LayoutChunkIcon {
         match chunk {
             LayoutChunkValue::Icon(i) => *i,
+            _ => panic!("Wrong type?"),
+        }
+    }
+
+    fn get_link(chunk: &LayoutChunkValue) -> &String {
+        match chunk {
+            LayoutChunkValue::Link(s) => s,
             _ => panic!("Wrong type?"),
         }
     }
@@ -400,7 +436,7 @@ mod tests {
         assert_points_equal(Point::init(162, 10), result.chunks[2].position);
     }
 
-    //#[test]
+    #[test]
     fn layout_line_with_link() {
         let result = layout_text(
             "Hello [[World]] Bye",
@@ -410,15 +446,15 @@ mod tests {
         .unwrap();
         assert_eq!(3, result.chunks.len());
         assert_eq!("Hello", get_text(&result.chunks[0].value));
-        assert_eq!("World", get_text(&result.chunks[1].value));
+        assert_eq!("World", get_link(&result.chunks[1].value));
         assert_eq!("Bye", get_text(&result.chunks[2].value));
-        assert_eq!(2, result.line_count);
+        assert_eq!(1, result.line_count);
         assert_points_equal(Point::init(10, 10), result.chunks[0].position);
-        assert_points_equal(Point::init(10, 37), result.chunks[1].position);
-        assert_points_equal(Point::init(10, 10), result.chunks[2].position);
+        assert_points_equal(Point::init(45, 10), result.chunks[1].position);
+        assert_points_equal(Point::init(85, 10), result.chunks[2].position);
     }
 
-    //#[test]
+    #[test]
     fn layout_line_with_link_sandwhich() {
         let result = layout_text(
             "A [[World]] B",
@@ -428,11 +464,20 @@ mod tests {
         .unwrap();
         assert_eq!(3, result.chunks.len());
         assert_eq!("A", get_text(&result.chunks[0].value));
-        assert_eq!("World", get_text(&result.chunks[1].value));
+        assert_eq!("World", get_link(&result.chunks[1].value));
         assert_eq!("B", get_text(&result.chunks[2].value));
         assert_eq!(1, result.line_count);
         assert_points_equal(Point::init(10, 10), result.chunks[0].position);
-        assert_points_equal(Point::init(10, 10), result.chunks[1].position);
-        assert_points_equal(Point::init(10, 10), result.chunks[2].position);
+        assert_points_equal(Point::init(23, 10), result.chunks[1].position);
+        assert_points_equal(Point::init(63, 10), result.chunks[2].position);
+    }
+
+    #[test]
+    fn recognize_link_with_parens() {
+        let result = layout_text("([[Sword]])", &get_test_font(), LayoutRequest::init(10, 10, 32 + 39 /*sizeof Hello World*/, 10)).unwrap();
+        assert_eq!(3, result.chunks.len());
+        assert_eq!("(", get_text(&result.chunks[0].value));
+        assert_eq!("Sword", get_link(&result.chunks[1].value));
+        assert_eq!(")", get_text(&result.chunks[2].value));
     }
 }

--- a/src/after_image/text_layout.rs
+++ b/src/after_image/text_layout.rs
@@ -122,11 +122,18 @@ mod tests {
         font
     }
 
+    fn get_text(chunk: &LayoutChunkValue) -> &String {
+        match chunk {
+            LayoutChunkValue::String(s) => s,
+            _ => panic!("Wrong type?"),
+        }
+    }
+
     #[test]
     fn layout_one_line() {
         let result = layout_text("Hello World", &get_test_font(), LayoutRequest::init(10, 10, 32 + 39 /*sizeof Hello World*/, 10)).unwrap();
         assert_eq!(1, result.chunks.len());
-        assert_eq!("Hello World", result.chunks[0].text);
+        assert_eq!("Hello World", get_text(&result.chunks[0].value));
         assert_eq!(1, result.line_count);
         assert_points_equal(Point::init(10, 10), result.chunks[0].position);
     }
@@ -140,9 +147,9 @@ mod tests {
         )
         .unwrap();
         assert_eq!(3, result.chunks.len());
-        assert_eq!("Hello World", result.chunks[0].text);
-        assert_eq!("Hello World", result.chunks[1].text);
-        assert_eq!("Hello", result.chunks[2].text);
+        assert_eq!("Hello World", get_text(&result.chunks[0].value));
+        assert_eq!("Hello World", get_text(&result.chunks[1].value));
+        assert_eq!("Hello", get_text(&result.chunks[2].value));
         assert_eq!(3, result.line_count);
         assert_points_equal(Point::init(10, 10), result.chunks[0].position);
     }
@@ -156,7 +163,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(1, result.chunks.len());
-        assert_eq!("HelloWorldHelloWorldHello", result.chunks[0].text);
+        assert_eq!("HelloWorldHelloWorldHello", get_text(&result.chunks[0].value));
         assert_eq!(1, result.line_count);
         assert_points_equal(Point::init(10, 10), result.chunks[0].position);
     }
@@ -170,9 +177,9 @@ mod tests {
         )
         .unwrap();
         assert_eq!(3, result.chunks.len());
-        assert_eq!("Hello", result.chunks[0].text);
-        assert_eq!("World", result.chunks[1].text);
-        assert_eq!("Bye", result.chunks[2].text);
+        assert_eq!("Hello", get_text(&result.chunks[0].value));
+        assert_eq!("World", get_text(&result.chunks[1].value));
+        assert_eq!("Bye", get_text(&result.chunks[2].value));
         assert_eq!(2, result.line_count);
         assert_points_equal(Point::init(10, 10), result.chunks[0].position);
         assert_points_equal(Point::init(10, 37), result.chunks[1].position);
@@ -188,9 +195,9 @@ mod tests {
         )
         .unwrap();
         assert_eq!(3, result.chunks.len());
-        assert_eq!("A", result.chunks[0].text);
-        assert_eq!("World", result.chunks[1].text);
-        assert_eq!("B", result.chunks[2].text);
+        assert_eq!("A", get_text(&result.chunks[0].value));
+        assert_eq!("World", get_text(&result.chunks[1].value));
+        assert_eq!("B", get_text(&result.chunks[2].value));
         assert_eq!(1, result.line_count);
         assert_points_equal(Point::init(10, 10), result.chunks[0].position);
         assert_points_equal(Point::init(10, 10), result.chunks[1].position);

--- a/src/after_image/text_layout.rs
+++ b/src/after_image/text_layout.rs
@@ -344,7 +344,7 @@ mod tests {
         assert_eq!(1, result.line_count);
         assert_points_equal(Point::init(10, 10), result.chunks[0].position);
         assert_points_equal(Point::init(20, 10), result.chunks[1].position);
-        assert_points_equal(Point::init(40, 10), result.chunks[2].position);
+        assert_points_equal(Point::init(35, 10), result.chunks[2].position);
     }
 
     #[test]
@@ -360,7 +360,7 @@ mod tests {
         assert!(get_icon(&result.chunks[1].value).is_sword());
         assert_eq!(1, result.line_count);
         assert_points_equal(Point::init(10, 10), result.chunks[0].position);
-        assert_points_equal(Point::init(30, 10), result.chunks[1].position);
+        assert_points_equal(Point::init(25, 10), result.chunks[1].position);
     }
 
     #[test]
@@ -384,7 +384,7 @@ mod tests {
         assert_points_equal(Point::init(42, 37), result.chunks[2].position);
         assert_points_equal(Point::init(10, 64), result.chunks[3].position);
         assert_points_equal(Point::init(10, 91), result.chunks[4].position);
-        assert_points_equal(Point::init(30, 91), result.chunks[5].position);
+        assert_points_equal(Point::init(25, 91), result.chunks[5].position);
     }
 
     #[test]
@@ -397,7 +397,7 @@ mod tests {
         assert_eq!(1, result.line_count);
         assert_points_equal(Point::init(10, 10), result.chunks[0].position);
         assert_points_equal(Point::init(147, 10), result.chunks[1].position);
-        assert_points_equal(Point::init(167, 10), result.chunks[2].position);
+        assert_points_equal(Point::init(162, 10), result.chunks[2].position);
     }
 
     //#[test]

--- a/src/after_image/text_layout.rs
+++ b/src/after_image/text_layout.rs
@@ -27,6 +27,7 @@ pub struct LayoutChunk {
 
 pub struct LayoutResult {
     pub chunks: Vec<LayoutChunk>,
+    pub line_count: u32,
 }
 
 struct Layout {
@@ -41,7 +42,7 @@ struct Layout {
 impl Layout {
     fn init(request: LayoutRequest) -> Layout {
         Layout {
-            result: LayoutResult { chunks: vec![] },
+            result: LayoutResult { chunks: vec![], line_count: 0 },
             current_line_width: 0,
             largest_line_height: 0,
             current_line: String::new(),
@@ -67,6 +68,7 @@ impl Layout {
                 self.create_next_chunk();
                 self.current_y_offset += self.largest_line_height + self.request.space_between_lines;
                 self.largest_line_height = 0;
+                self.result.line_count += 1;
             }
 
             self.largest_line_height = cmp::max(self.largest_line_height, height);

--- a/src/after_image/text_layout.rs
+++ b/src/after_image/text_layout.rs
@@ -292,6 +292,11 @@ mod tests {
         static ref TTF_CONTEXT: &'static sdl2::ttf::Sdl2TtfContext = Box::from(sdl2::ttf::init().unwrap()).leak();
     }
 
+    fn has_test_font() -> bool {
+        let font_path = Path::new(&get_exe_folder()).join("fonts").join("LibreFranklin-Regular.ttf");
+        font_path.exists()
+    }
+
     fn get_test_font() -> Font {
         let font_path = Path::new(&get_exe_folder()).join("fonts").join("LibreFranklin-Regular.ttf");
         let mut font = TTF_CONTEXT.load_font(font_path, 14).unwrap();
@@ -329,6 +334,10 @@ mod tests {
 
     #[test]
     fn layout_one_line() {
+        if !has_test_font() {
+            return;
+        }
+
         let result = layout_text("Hello World", &get_test_font(), LayoutRequest::init(10, 10, 32 + 39 /*sizeof Hello World*/, 10)).unwrap();
         assert_eq!(1, result.chunks.len());
         assert_eq!("Hello World", get_text(&result.chunks[0].value));
@@ -338,6 +347,10 @@ mod tests {
 
     #[test]
     fn layout_multiple_line() {
+        if !has_test_font() {
+            return;
+        }
+
         let result = layout_text(
             "Hello World Hello World Hello",
             &get_test_font(),
@@ -356,6 +369,10 @@ mod tests {
 
     #[test]
     fn layout_one_super_long_word() {
+        if !has_test_font() {
+            return;
+        }
+
         let result = layout_text(
             "HelloWorldHelloWorldHello",
             &get_test_font(),
@@ -370,6 +387,10 @@ mod tests {
 
     #[test]
     fn recognize_icon_with_parens() {
+        if !has_test_font() {
+            return;
+        }
+
         let result = layout_text("({{Sword}})", &get_test_font(), LayoutRequest::init(10, 10, 32 + 39 /*sizeof Hello World*/, 10)).unwrap();
         assert_eq!(3, result.chunks.len());
         assert_eq!("(", get_text(&result.chunks[0].value));
@@ -379,6 +400,10 @@ mod tests {
 
     #[test]
     fn layout_line_with_icon() {
+        if !has_test_font() {
+            return;
+        }
+
         let result = layout_text(
             "A {{Sword}} B",
             &get_test_font(),
@@ -397,6 +422,10 @@ mod tests {
 
     #[test]
     fn layout_line_with_duel_icons() {
+        if !has_test_font() {
+            return;
+        }
+
         let result = layout_text(
             "{{Sword}} {{Sword}}",
             &get_test_font(),
@@ -413,6 +442,10 @@ mod tests {
 
     #[test]
     fn layout_icon_multiline_text() {
+        if !has_test_font() {
+            return;
+        }
+
         let result = layout_text(
             "Hello World Hello {{Sword}} LongerWorld {{Sword}} Board",
             &get_test_font(),
@@ -437,6 +470,10 @@ mod tests {
 
     #[test]
     fn layout_icon_multiline_text_tiny() {
+        if !has_test_font() {
+            return;
+        }
+
         let result = layout_text(
             "Hello World Hello {{Sword}} LongerWorld {{Sword}} Board",
             &get_tiny_test_font(),
@@ -459,6 +496,10 @@ mod tests {
 
     #[test]
     fn layout_icon_paren_combat_text() {
+        if !has_test_font() {
+            return;
+        }
+
         let result = layout_text("Player took 4 damage ({{Sword}} 4).", &get_test_font(), LayoutRequest::init(10, 10, 210, 10)).unwrap();
         assert_eq!(3, result.chunks.len());
         assert_eq!("Player took 4 damage (", get_text(&result.chunks[0].value));
@@ -472,6 +513,10 @@ mod tests {
 
     #[test]
     fn layout_line_with_link() {
+        if !has_test_font() {
+            return;
+        }
+
         let result = layout_text(
             "Hello [[World]] Bye",
             &get_test_font(),
@@ -490,6 +535,10 @@ mod tests {
 
     #[test]
     fn layout_line_with_link_sandwhich() {
+        if !has_test_font() {
+            return;
+        }
+
         let result = layout_text(
             "A [[World]] B",
             &get_test_font(),
@@ -508,6 +557,10 @@ mod tests {
 
     #[test]
     fn recognize_link_with_parens() {
+        if !has_test_font() {
+            return;
+        }
+
         let result = layout_text("([[Sword]])", &get_test_font(), LayoutRequest::init(10, 10, 32 + 39 /*sizeof Hello World*/, 10)).unwrap();
         assert_eq!(3, result.chunks.len());
         assert_eq!("(", get_text(&result.chunks[0].value));

--- a/src/after_image/text_layout.rs
+++ b/src/after_image/text_layout.rs
@@ -20,9 +20,13 @@ impl LayoutRequest {
     }
 }
 
+pub enum LayoutChunkValue {
+    String(String),
+}
+
 pub struct LayoutChunk {
     pub position: Point,
-    pub text: String,
+    pub value: LayoutChunkValue,
 }
 
 pub struct LayoutResult {
@@ -53,7 +57,7 @@ impl Layout {
 
     fn create_next_chunk(&mut self) {
         self.result.chunks.push(LayoutChunk {
-            text: mem::replace(&mut self.current_line, String::new()),
+            value: LayoutChunkValue::String(mem::replace(&mut self.current_line, String::new())),
             position: Point::init(self.request.position.x, self.current_y_offset),
         });
         self.current_line = String::new();

--- a/src/after_image/text_renderer.rs
+++ b/src/after_image/text_renderer.rs
@@ -13,6 +13,7 @@ pub enum FontSize {
     Micro,
     Tiny,
     Small,
+    SmallUnderline,
     Large,
     Bold,
 }
@@ -37,6 +38,7 @@ pub struct TextRenderer {
     micro_font: Font,
     tiny_font: Font,
     small_font: Font,
+    small_underline_font: Font,
     bold_font: Font,
     large_font: Font,
 }
@@ -51,6 +53,8 @@ impl TextRenderer {
         tiny_font.set_style(sdl2::ttf::FontStyle::NORMAL);
         let mut small_font = font_context.ttf_context.load_font(font_path.clone(), 14)?;
         small_font.set_style(sdl2::ttf::FontStyle::NORMAL);
+        let mut small_underline_font = font_context.ttf_context.load_font(font_path.clone(), 14)?;
+        small_underline_font.set_style(sdl2::ttf::FontStyle::UNDERLINE);
         let mut bold_font = font_context.ttf_context.load_font(font_path.clone(), 16)?;
         bold_font.set_style(sdl2::ttf::FontStyle::BOLD);
         let mut large_font = font_context.ttf_context.load_font(font_path, 20)?;
@@ -61,6 +65,7 @@ impl TextRenderer {
             micro_font,
             tiny_font,
             small_font,
+            small_underline_font,
             bold_font,
             large_font,
         })
@@ -71,13 +76,14 @@ impl TextRenderer {
             FontSize::Micro => &self.micro_font,
             FontSize::Tiny => &self.tiny_font,
             FontSize::Small => &self.small_font,
+            FontSize::SmallUnderline => &self.small_underline_font,
             FontSize::Bold => &self.bold_font,
             FontSize::Large => &self.large_font,
         }
     }
 
     pub fn layout_text(&self, text: &str, size: FontSize, request: LayoutRequest) -> BoxResult<LayoutResult> {
-        super::font_layout::layout_text(text, self.get_font(size), request)
+        super::text_layout::layout_text(text, self.get_font(size), request)
     }
 
     pub fn render_texture(&self, canvas: &RenderCanvas, text: &str, size: FontSize, color: FontColor) -> BoxResult<Texture> {

--- a/src/after_image/text_renderer.rs
+++ b/src/after_image/text_renderer.rs
@@ -5,12 +5,13 @@ use sdl2::pixels::Color;
 use sdl2::rect::Rect as SDLRect;
 use sdl2::render::{Texture, TextureQuery};
 
-use super::{FontCache, FontContext, RenderCanvas};
+use super::{FontCache, FontContext, LayoutRequest, LayoutResult, RenderCanvas};
 use crate::atlas::{get_exe_folder, BoxResult};
 
 #[allow(dead_code)]
 pub enum FontSize {
     Micro,
+    Tiny,
     Small,
     Large,
     Bold,
@@ -34,6 +35,7 @@ pub type Font = sdl2::ttf::Font<'static, 'static>;
 pub struct TextRenderer {
     cache: RefCell<FontCache>,
     micro_font: Font,
+    tiny_font: Font,
     small_font: Font,
     bold_font: Font,
     large_font: Font,
@@ -45,6 +47,8 @@ impl TextRenderer {
 
         let mut micro_font = font_context.ttf_context.load_font(font_path.clone(), 9)?;
         micro_font.set_style(sdl2::ttf::FontStyle::BOLD);
+        let mut tiny_font = font_context.ttf_context.load_font(font_path.clone(), 12)?;
+        tiny_font.set_style(sdl2::ttf::FontStyle::NORMAL);
         let mut small_font = font_context.ttf_context.load_font(font_path.clone(), 14)?;
         small_font.set_style(sdl2::ttf::FontStyle::NORMAL);
         let mut bold_font = font_context.ttf_context.load_font(font_path.clone(), 16)?;
@@ -55,26 +59,35 @@ impl TextRenderer {
         Ok(TextRenderer {
             cache: RefCell::new(FontCache::init()),
             micro_font,
+            tiny_font,
             small_font,
             bold_font,
             large_font,
         })
     }
 
-    pub fn render_texture(&self, canvas: &RenderCanvas, text: &str, size: FontSize, color: FontColor) -> BoxResult<Texture> {
-        let font = match size {
+    fn get_font(&self, size: FontSize) -> &Font {
+        match size {
             FontSize::Micro => &self.micro_font,
+            FontSize::Tiny => &self.tiny_font,
             FontSize::Small => &self.small_font,
             FontSize::Bold => &self.bold_font,
             FontSize::Large => &self.large_font,
-        };
+        }
+    }
+
+    pub fn layout_text(&self, text: &str, size: FontSize, request: LayoutRequest) -> BoxResult<LayoutResult> {
+        super::font_layout::layout_text(text, self.get_font(size), request)
+    }
+
+    pub fn render_texture(&self, canvas: &RenderCanvas, text: &str, size: FontSize, color: FontColor) -> BoxResult<Texture> {
         let color = match color {
             FontColor::Black => Color::RGB(0, 0, 0),
             FontColor::White => Color::RGB(255, 255, 255),
             FontColor::Red => Color::RGB(255, 0, 0),
         };
 
-        let surface = font.render(text).solid(color).map_err(|e| e.to_string())?;
+        let surface = self.get_font(size).render(text).blended(color).map_err(|e| e.to_string())?;
         let texture_creator = canvas.texture_creator();
         let mut texture = texture_creator.create_texture_from_surface(&surface).map_err(|e| e.to_string())?;
         texture.set_blend_mode(sdl2::render::BlendMode::Blend);

--- a/src/after_image/text_renderer.rs
+++ b/src/after_image/text_renderer.rs
@@ -22,6 +22,8 @@ pub enum FontColor {
     Red,
 }
 
+pub type Font = sdl2::ttf::Font<'static, 'static>;
+
 // So this is either a beautiful hack, or an abuse
 // The SDL font code wants two lifetimes, which requires
 // TextRenderer to have a lifeime, which causes a bunch
@@ -31,10 +33,10 @@ pub enum FontColor {
 // This is safe, right?!?
 pub struct TextRenderer {
     cache: RefCell<FontCache>,
-    micro_font: sdl2::ttf::Font<'static, 'static>,
-    small_font: sdl2::ttf::Font<'static, 'static>,
-    bold_font: sdl2::ttf::Font<'static, 'static>,
-    large_font: sdl2::ttf::Font<'static, 'static>,
+    micro_font: Font,
+    small_font: Font,
+    bold_font: Font,
+    large_font: Font,
 }
 
 impl TextRenderer {

--- a/src/after_image/text_renderer.rs
+++ b/src/after_image/text_renderer.rs
@@ -106,6 +106,12 @@ impl TextRenderer {
         let TextureQuery { width, height, .. } = texture.query();
         canvas.copy(&texture, SDLRect::new(0, 0, width, height), SDLRect::new(x, y, width, height))?;
 
+        #[cfg(feature = "debug_text_alignmnet")]
+        {
+            canvas.set_draw_color(Color::from((128, 0, 0, 128)));
+            canvas.fill_rect(SDLRect::new(x, y, width, height))?;
+        }
+
         Ok(())
     }
 }

--- a/src/arena/animations.rs
+++ b/src/arena/animations.rs
@@ -1,6 +1,6 @@
 use specs::prelude::*;
 
-use super::{AccelerateAnimations, AnimationComponent};
+use super::{AccelerateAnimationsComponent, AnimationComponent};
 use crate::after_image::CharacterAnimationState;
 use crate::atlas::{EasyMutECS, EasyMutWorld, Point};
 use crate::clash::{EventCoordinator, EventKind};
@@ -143,7 +143,7 @@ pub fn tick_animations(ecs: &mut World, frame: u64) {
 }
 
 pub fn add_animation(ecs: &mut World, entity: Entity, mut animation: Animation) {
-    if ecs.read_resource::<AccelerateAnimations>().state {
+    if ecs.read_resource::<AccelerateAnimationsComponent>().state {
         animation.duration /= 4;
     }
     ecs.shovel(entity, AnimationComponent::init(animation));
@@ -162,7 +162,7 @@ pub fn accelerate_animations(ecs: &mut World) {
     for a in to_speedup {
         ecs.write_storage::<AnimationComponent>().grab_mut(a).animation.duration /= 4;
     }
-    ecs.write_resource::<AccelerateAnimations>().state = true;
+    ecs.write_resource::<AccelerateAnimationsComponent>().state = true;
 }
 
 pub fn force_complete_animations(ecs: &mut World) {

--- a/src/arena/battle_actions.rs
+++ b/src/arena/battle_actions.rs
@@ -13,7 +13,7 @@ pub enum BattleActionRequest {
 }
 
 pub fn request_action(ecs: &mut World, request: BattleActionRequest) {
-    ecs.write_resource::<AccelerateAnimations>().state = false;
+    ecs.write_resource::<AccelerateAnimationsComponent>().state = false;
 
     let animation_blocked = has_animations_blocking(ecs);
     let action_blocked = !can_act(ecs);

--- a/src/arena/battle_scene.rs
+++ b/src/arena/battle_scene.rs
@@ -46,7 +46,6 @@ impl BattleScene {
         for i in 0..25 {
             ecs.log(format!("{}", i));
         }
-        ecs.log("A {{Sword}} hits");
 
         Ok(BattleScene { ecs, views })
     }

--- a/src/arena/battle_scene.rs
+++ b/src/arena/battle_scene.rs
@@ -23,7 +23,7 @@ pub struct BattleScene {
 
 impl BattleScene {
     pub fn init(render_context_holder: &RenderContextHolder, text_renderer: &Rc<TextRenderer>, difficulty: u32) -> BoxResult<BattleScene> {
-        let mut ecs = new_game::random_new_world(difficulty).unwrap();
+        let ecs = new_game::random_new_world(difficulty).unwrap();
 
         let render_context = &render_context_holder.borrow();
         let mut views: Vec<Box<dyn View>> = vec![
@@ -41,10 +41,6 @@ impl BattleScene {
 
         if cfg!(debug_assertions) {
             views.push(Box::from(DebugView::init(SDLPoint::new(20, 20), Rc::clone(&text_renderer))?));
-        }
-
-        for i in 0..25 {
-            ecs.log(format!("{}", i));
         }
 
         Ok(BattleScene { ecs, views })

--- a/src/arena/battle_scene.rs
+++ b/src/arena/battle_scene.rs
@@ -167,8 +167,12 @@ impl BattleScene {
 impl Scene for BattleScene {
     fn handle_key(&mut self, keycode: Keycode) {
         match keycode {
-            Keycode::PageUp => self.ecs.log_scroll_back(),
-            Keycode::PageDown => self.ecs.log_scroll_forward(),
+            Keycode::PageUp => {
+                self.ecs.raise_event(EventKind::LogScrolled(LogDirection::Backwards), None);
+            }
+            Keycode::PageDown => {
+                self.ecs.raise_event(EventKind::LogScrolled(LogDirection::Forward), None);
+            }
             _ => {}
         }
 

--- a/src/arena/battle_scene.rs
+++ b/src/arena/battle_scene.rs
@@ -46,6 +46,7 @@ impl BattleScene {
         for i in 0..25 {
             ecs.log(format!("{}", i));
         }
+        ecs.log("A {{Sword}} hits");
 
         Ok(BattleScene { ecs, views })
     }

--- a/src/arena/battle_scene.rs
+++ b/src/arena/battle_scene.rs
@@ -23,7 +23,7 @@ pub struct BattleScene {
 
 impl BattleScene {
     pub fn init(render_context_holder: &RenderContextHolder, text_renderer: &Rc<TextRenderer>, difficulty: u32) -> BoxResult<BattleScene> {
-        let ecs = new_game::random_new_world(difficulty).unwrap();
+        let mut ecs = new_game::random_new_world(difficulty).unwrap();
 
         let render_context = &render_context_holder.borrow();
         let mut views: Vec<Box<dyn View>> = vec![
@@ -41,6 +41,10 @@ impl BattleScene {
 
         if cfg!(debug_assertions) {
             views.push(Box::from(DebugView::init(SDLPoint::new(20, 20), Rc::clone(&text_renderer))?));
+        }
+
+        for i in 0..25 {
+            ecs.log(format!("{}", i));
         }
 
         Ok(BattleScene { ecs, views })

--- a/src/arena/components.rs
+++ b/src/arena/components.rs
@@ -105,6 +105,28 @@ impl AccelerateAnimations {
     }
 }
 
+pub enum LogIndexDelta {
+    None,
+    PageUp,
+    PageDown,
+    JumpToEnd,
+}
+
+#[derive(Component)] // NotConvertSaveload
+pub struct LogIndexPosition {
+    pub index: usize,
+    pub delta: LogIndexDelta,
+}
+
+impl LogIndexPosition {
+    pub fn init() -> LogIndexPosition {
+        LogIndexPosition {
+            index: 0,
+            delta: LogIndexDelta::None,
+        }
+    }
+}
+
 pub fn add_ui_extension(ecs: &mut World) {
     ecs.register::<RenderComponent>();
     ecs.register::<BattleSceneStateComponent>();
@@ -119,11 +141,13 @@ pub fn add_ui_extension(ecs: &mut World) {
     ecs.subscribe(super::battle_animations::melee_cone_event);
     ecs.subscribe(super::battle_animations::field_event);
     ecs.subscribe(super::battle_animations::explode_event);
+    ecs.subscribe(super::views::log_event);
 
     ecs.insert(BattleSceneStateComponent::init());
     ecs.insert(MousePositionComponent::init());
     ecs.insert(BufferedInputComponent::init());
     ecs.insert(AccelerateAnimations::init());
+    ecs.insert(LogIndexPosition::init());
 }
 
 pub trait UIState {

--- a/src/arena/components.rs
+++ b/src/arena/components.rs
@@ -99,9 +99,9 @@ pub struct AccelerateAnimationsComponent {
     pub state: bool,
 }
 
-impl AccelerateAnimations {
-    pub fn init() -> AccelerateAnimations {
-        AccelerateAnimations { state: false }
+impl AccelerateAnimationsComponent {
+    pub fn init() -> AccelerateAnimationsComponent {
+        AccelerateAnimationsComponent { state: false }
     }
 }
 
@@ -146,7 +146,7 @@ pub fn add_ui_extension(ecs: &mut World) {
     ecs.insert(BattleSceneStateComponent::init());
     ecs.insert(MousePositionComponent::init());
     ecs.insert(BufferedInputComponent::init());
-    ecs.insert(AccelerateAnimations::init());
+    ecs.insert(AccelerateAnimationsComponent::init());
     ecs.insert(LogIndexPosition::init());
 }
 

--- a/src/arena/components.rs
+++ b/src/arena/components.rs
@@ -95,7 +95,7 @@ impl BufferedInputComponent {
 }
 
 #[derive(Component)] // NotConvertSaveload
-pub struct AccelerateAnimations {
+pub struct AccelerateAnimationsComponent {
     pub state: bool,
 }
 

--- a/src/arena/views.rs
+++ b/src/arena/views.rs
@@ -36,7 +36,7 @@ pub trait View {
 pub use character_overlay::CharacterOverlay;
 pub use debug::DebugView;
 pub use infobar::InfoBarView;
-pub use log::LogView;
+pub use log::{log_event, LogView};
 pub use map::{screen_rect_for_map_grid, screen_to_map_position, MapView, MAP_CORNER_Y, TILE_SIZE};
 pub use skillbar::{get_current_skill_on_skillbar, get_skill_name_on_skillbar, hotkey_to_skill_index, SkillBarView};
 pub use status_display::StatusBarView;

--- a/src/arena/views/log.rs
+++ b/src/arena/views/log.rs
@@ -87,7 +87,17 @@ impl LogView {
                                 chunk.position.x as i32,
                                 line_y_offset + chunk.position.y as i32,
                                 canvas,
-                                FontSize::Tiny,
+                                FontSize::Small,
+                                FontColor::Black,
+                            )?;
+                        }
+                        LayoutChunkValue::Link(s) => {
+                            self.text.render_text(
+                                &s,
+                                chunk.position.x as i32,
+                                line_y_offset + chunk.position.y as i32,
+                                canvas,
+                                FontSize::SmallUnderline,
                                 FontColor::Black,
                             )?;
                         }

--- a/src/arena/views/log.rs
+++ b/src/arena/views/log.rs
@@ -139,8 +139,8 @@ pub fn log_event(ecs: &mut World, kind: EventKind, _target: Option<Entity>) {
         EventKind::LogScrolled(direction) => match direction {
             LogDirection::Forward => ecs.write_resource::<LogIndexPosition>().delta = LogIndexDelta::PageDown,
             LogDirection::Backwards => ecs.write_resource::<LogIndexPosition>().delta = LogIndexDelta::PageUp,
+            LogDirection::SnapToEnd => ecs.write_resource::<LogIndexPosition>().delta = LogIndexDelta::JumpToEnd,
         },
-        EventKind::Tick(_) => ecs.write_resource::<LogIndexPosition>().delta = LogIndexDelta::JumpToEnd,
         _ => {}
     }
 }

--- a/src/arena/views/log.rs
+++ b/src/arena/views/log.rs
@@ -8,7 +8,7 @@ use super::super::{LogIndexDelta, LogIndexPosition};
 use super::view_components::{Frame, FrameKind};
 use super::{ContextData, View};
 use crate::after_image::{
-    FontColor, FontSize, IconCache, IconLoader, LayoutChunkIcon, LayoutChunkValue, LayoutRequest, RenderCanvas, RenderContext, TextRenderer,
+    FontColor, FontSize, IconCache, IconLoader, LayoutChunkIcon, LayoutChunkValue, LayoutRequest, RenderCanvas, RenderContext, TextRenderer, TEXT_ICON_SIZE,
 };
 use crate::atlas::BoxResult;
 use crate::clash::{EventKind, LogComponent, LogDirection, LOG_COUNT};
@@ -31,7 +31,7 @@ impl LogView {
                 &IconLoader::init_ui()?,
                 FrameKind::Log,
             )?,
-            icons: IconCache::init(render_context, IconLoader::init_symbols()?, &["stiletto.png"])?,
+            icons: IconCache::init(render_context, IconLoader::init_symbols()?, &["plain-dagger.png"])?,
         })
     }
 
@@ -78,27 +78,34 @@ impl LogView {
                 LayoutRequest::init(self.position.x as u32, self.position.y as u32 + 15, 210, 2),
             )?;
             if line_count + layout.line_count <= LOG_COUNT as u32 {
+                let line_y_offset = 20 * line_count as i32;
                 for chunk in &layout.chunks {
                     match &chunk.value {
                         LayoutChunkValue::String(s) => {
                             self.text.render_text(
                                 &s,
                                 chunk.position.x as i32,
-                                chunk.position.y as i32 + 20 * line_count as i32,
+                                line_y_offset + chunk.position.y as i32,
                                 canvas,
                                 FontSize::Tiny,
                                 FontColor::Black,
                             )?;
                         }
-                        LayoutChunkValue::Icon(icon) => match icon {
-                            LayoutChunkIcon::Sword => {
-                                canvas.copy(
-                                    self.icons.get("stiletto.png"),
-                                    None,
-                                    SDLRect::new(chunk.position.x as i32, chunk.position.y as i32, 24, 24),
-                                )?;
-                            }
-                        },
+                        LayoutChunkValue::Icon(icon) => {
+                            let icon_image = match icon {
+                                LayoutChunkIcon::Sword => self.icons.get("plain-dagger.png"),
+                            };
+                            canvas.copy(
+                                icon_image,
+                                None,
+                                SDLRect::new(
+                                    chunk.position.x as i32,
+                                    line_y_offset + chunk.position.y as i32 - 2,
+                                    TEXT_ICON_SIZE,
+                                    TEXT_ICON_SIZE,
+                                ),
+                            )?;
+                        }
                     }
                 }
 

--- a/src/arena/views/log.rs
+++ b/src/arena/views/log.rs
@@ -6,7 +6,7 @@ use specs::prelude::*;
 use super::super::{LogIndexDelta, LogIndexPosition};
 use super::view_components::{Frame, FrameKind};
 use super::{ContextData, View};
-use crate::after_image::{FontColor, FontSize, IconLoader, LayoutRequest, RenderCanvas, RenderContext, TextRenderer};
+use crate::after_image::{FontColor, FontSize, IconLoader, LayoutChunkValue, LayoutRequest, RenderCanvas, RenderContext, TextRenderer};
 use crate::atlas::BoxResult;
 use crate::clash::{EventKind, LogComponent, LogDirection, LOG_COUNT};
 
@@ -74,14 +74,18 @@ impl LogView {
             )?;
             if line_count + layout.line_count <= LOG_COUNT as u32 {
                 for chunk in &layout.chunks {
-                    self.text.render_text(
-                        &chunk.text,
-                        chunk.position.x as i32,
-                        chunk.position.y as i32 + 20 * line_count as i32,
-                        canvas,
-                        FontSize::Tiny,
-                        FontColor::Black,
-                    )?;
+                    match &chunk.value {
+                        LayoutChunkValue::String(s) => {
+                            self.text.render_text(
+                                &s,
+                                chunk.position.x as i32,
+                                chunk.position.y as i32 + 20 * line_count as i32,
+                                canvas,
+                                FontSize::Tiny,
+                                FontColor::Black,
+                            )?;
+                        }
+                    }
                 }
 
                 line_count += layout.line_count;

--- a/src/arena/views/log.rs
+++ b/src/arena/views/log.rs
@@ -99,8 +99,8 @@ impl LogView {
                                 icon_image,
                                 None,
                                 SDLRect::new(
-                                    chunk.position.x as i32,
-                                    line_y_offset + chunk.position.y as i32 - 2,
+                                    chunk.position.x as i32 - 4,
+                                    line_y_offset + chunk.position.y as i32 - 1,
                                     TEXT_ICON_SIZE,
                                     TEXT_ICON_SIZE,
                                 ),

--- a/src/arena/views/log.rs
+++ b/src/arena/views/log.rs
@@ -108,13 +108,19 @@ impl LogView {
                             canvas.copy(
                                 icon_image,
                                 None,
-                                SDLRect::new(
-                                    chunk.position.x as i32 - 4,
+                                SDLRect::new(chunk.position.x as i32, line_y_offset + chunk.position.y as i32, TEXT_ICON_SIZE, TEXT_ICON_SIZE),
+                            )?;
+
+                            #[cfg(feature = "debug_text_alignmnet")]
+                            {
+                                canvas.set_draw_color(sdl2::pixels::Color::from((0, 128, 0, 128)));
+                                canvas.fill_rect(SDLRect::new(
+                                    chunk.position.x as i32,
                                     line_y_offset + chunk.position.y as i32 - 1,
                                     TEXT_ICON_SIZE,
                                     TEXT_ICON_SIZE,
-                                ),
-                            )?;
+                                ))?;
+                            }
                         }
                     }
                 }

--- a/src/arena/views/log.rs
+++ b/src/arena/views/log.rs
@@ -5,7 +5,7 @@ use specs::prelude::*;
 
 use super::view_components::{Frame, FrameKind};
 use super::{ContextData, View};
-use crate::after_image::{FontColor, FontSize, IconLoader, RenderCanvas, RenderContext, TextRenderer};
+use crate::after_image::{FontColor, FontSize, IconLoader, LayoutRequest, RenderCanvas, RenderContext, TextRenderer};
 use crate::atlas::BoxResult;
 use crate::clash::{LogComponent, LOG_COUNT};
 
@@ -37,7 +37,7 @@ impl LogView {
                 self.position.x,
                 self.position.y + (i as i32 * 20) + 15,
                 canvas,
-                FontSize::Small,
+                FontSize::Tiny,
                 FontColor::Black,
             )?;
         }

--- a/src/arena/views/log.rs
+++ b/src/arena/views/log.rs
@@ -1,18 +1,22 @@
 use std::rc::Rc;
 
 use sdl2::rect::Point as SDLPoint;
+use sdl2::rect::Rect as SDLRect;
 use specs::prelude::*;
 
 use super::super::{LogIndexDelta, LogIndexPosition};
 use super::view_components::{Frame, FrameKind};
 use super::{ContextData, View};
-use crate::after_image::{FontColor, FontSize, IconLoader, LayoutChunkValue, LayoutRequest, RenderCanvas, RenderContext, TextRenderer};
+use crate::after_image::{
+    FontColor, FontSize, IconCache, IconLoader, LayoutChunkIcon, LayoutChunkValue, LayoutRequest, RenderCanvas, RenderContext, TextRenderer,
+};
 use crate::atlas::BoxResult;
 use crate::clash::{EventKind, LogComponent, LogDirection, LOG_COUNT};
 
 pub struct LogView {
     position: SDLPoint,
     text: Rc<TextRenderer>,
+    icons: IconCache,
     frame: Frame,
 }
 
@@ -27,6 +31,7 @@ impl LogView {
                 &IconLoader::init_ui()?,
                 FrameKind::Log,
             )?,
+            icons: IconCache::init(render_context, IconLoader::init_symbols()?, &["stiletto.png"])?,
         })
     }
 
@@ -85,6 +90,15 @@ impl LogView {
                                 FontColor::Black,
                             )?;
                         }
+                        LayoutChunkValue::Icon(icon) => match icon {
+                            LayoutChunkIcon::Sword => {
+                                canvas.copy(
+                                    self.icons.get("stiletto.png"),
+                                    None,
+                                    SDLRect::new(chunk.position.x as i32, chunk.position.y as i32, 24, 24),
+                                )?;
+                            }
+                        },
                     }
                 }
 

--- a/src/arena/views/log.rs
+++ b/src/arena/views/log.rs
@@ -32,14 +32,22 @@ impl LogView {
     fn render_log(&self, ecs: &World, canvas: &mut RenderCanvas) -> BoxResult<()> {
         let log = &ecs.read_resource::<LogComponent>().log;
         for (i, entry) in log.get(log.index, LOG_COUNT).iter().enumerate() {
-            self.text.render_text(
+            let layout = self.text.layout_text(
                 &entry,
-                self.position.x,
-                self.position.y + (i as i32 * 20) + 15,
-                canvas,
                 FontSize::Tiny,
-                FontColor::Black,
+                LayoutRequest::init(self.position.x as u32, self.position.y as u32 + (i as u32 * 20) + 15, 210, 2),
             )?;
+
+            for line in &layout.chunks {
+                self.text.render_text(
+                    &line.text,
+                    line.position.x as i32,
+                    line.position.y as i32,
+                    canvas,
+                    FontSize::Tiny,
+                    FontColor::Black,
+                )?;
+            }
         }
 
         Ok(())

--- a/src/clash/components.rs
+++ b/src/clash/components.rs
@@ -427,21 +427,11 @@ impl StatusApplier for World {
 
 pub trait Logger {
     fn log<T: AsRef<str>>(&mut self, message: T);
-    fn log_scroll_forward(&mut self);
-    fn log_scroll_back(&mut self);
 }
 
 impl Logger for World {
     fn log<T: AsRef<str>>(&mut self, message: T) {
         let log = &mut self.write_resource::<LogComponent>().log;
         log.add(message.as_ref());
-    }
-    fn log_scroll_forward(&mut self) {
-        let log = &mut self.write_resource::<LogComponent>().log;
-        log.scroll_forward();
-    }
-    fn log_scroll_back(&mut self) {
-        let log = &mut self.write_resource::<LogComponent>().log;
-        log.scroll_back();
     }
 }

--- a/src/clash/components.rs
+++ b/src/clash/components.rs
@@ -424,14 +424,3 @@ impl StatusApplier for World {
         StatusStore::add_trait_to(self, entity, kind);
     }
 }
-
-pub trait Logger {
-    fn log<T: AsRef<str>>(&mut self, message: T);
-}
-
-impl Logger for World {
-    fn log<T: AsRef<str>>(&mut self, message: T) {
-        let log = &mut self.write_resource::<LogComponent>().log;
-        log.add(message.as_ref());
-    }
-}

--- a/src/clash/damage.rs
+++ b/src/clash/damage.rs
@@ -120,7 +120,7 @@ fn apply_damage_core(ecs: &mut World, damage: Damage, target: &Entity, source_po
         }
     };
     ecs.log(format!(
-        "{} took {} damage (Str {}).",
+        "{} took {} damage ({{{{Sword}}}} {}).",
         ecs.get_name(&target).unwrap().as_str(),
         rolled_damage.amount,
         damage.dice()

--- a/src/clash/damage.rs
+++ b/src/clash/damage.rs
@@ -144,14 +144,14 @@ fn apply_damage_core(ecs: &mut World, damage: Damage, target: &Entity, source_po
             if let Some(new_origin) = direction_of_impact.point_in_direction(&current_position.origin) {
                 let new_position = current_position.move_to(new_origin);
                 if is_area_clear_of_others(ecs, &new_position.all_positions(), target) {
-                    ecs.log(format!("{} is knocked back", ecs.get_name(target).unwrap()));
+                    ecs.log(format!("{} is knocked back.", ecs.get_name(target).unwrap()));
                     begin_move(ecs, target, new_position, PostMoveAction::CheckNewLocationDamage);
                 }
             }
         }
     }
     if rolled_damage.options.contains(DamageOptions::ADD_CHARGE_STATUS) && !ecs.has_status(target, StatusKind::StaticCharge) {
-        ecs.log(format!("{} crackles with static electricity", ecs.get_name(target).unwrap()));
+        ecs.log(format!("{} crackles with static electricity.", ecs.get_name(target).unwrap()));
         ecs.add_status(target, StatusKind::StaticCharge, 300);
     }
     if rolled_damage.options.contains(DamageOptions::CONSUMES_CHARGE_DMG) && ecs.has_status(target, StatusKind::StaticCharge) {
@@ -169,7 +169,7 @@ fn apply_damage_core(ecs: &mut World, damage: Damage, target: &Entity, source_po
         if let Some(source_position) = source_position {
             if let Some(source) = find_character_at_location(ecs, source_position) {
                 if !ecs.has_status(&source, StatusKind::Aimed) {
-                    ecs.log(format!("{} takes aim", ecs.get_name(&source).unwrap()));
+                    ecs.log(format!("{} takes aim.", ecs.get_name(&source).unwrap()));
                     ecs.add_status(&source, StatusKind::Aimed, 300);
                 }
             }
@@ -192,7 +192,7 @@ pub fn regen_event(ecs: &mut World, kind: EventKind, target: Option<Entity>) {
                 if ecs.has_status(&target.unwrap(), StatusKind::Regen) {
                     ecs.add_status(&target.unwrap(), StatusKind::RegenTick, REGEN_DURATION);
                 } else {
-                    ecs.log(format!("{} stops regenerating", ecs.get_name(&target.unwrap()).unwrap()));
+                    ecs.log(format!("{} stops regenerating.", ecs.get_name(&target.unwrap()).unwrap()));
                 }
                 const HEALTH_REGEN_PER_TICK: u32 = 1;
                 apply_healing_to_character(ecs, Strength::init(HEALTH_REGEN_PER_TICK), &target.unwrap());

--- a/src/clash/damage.rs
+++ b/src/clash/damage.rs
@@ -120,7 +120,7 @@ fn apply_damage_core(ecs: &mut World, damage: Damage, target: &Entity, source_po
         }
     };
     ecs.log(format!(
-        "{} took {} damage ({{{{Sword}}}} {}).",
+        "{} took {} damage ({} {{{{Sword}}}})",
         ecs.get_name(&target).unwrap().as_str(),
         rolled_damage.amount,
         damage.dice()

--- a/src/clash/events.rs
+++ b/src/clash/events.rs
@@ -64,6 +64,7 @@ pub enum ExplodeState {
 pub enum LogDirection {
     Forward,
     Backwards,
+    SnapToEnd,
 }
 
 #[derive(Copy, Clone)]

--- a/src/clash/events.rs
+++ b/src/clash/events.rs
@@ -61,6 +61,12 @@ pub enum ExplodeState {
 }
 
 #[derive(Copy, Clone)]
+pub enum LogDirection {
+    Forward,
+    Backwards,
+}
+
+#[derive(Copy, Clone)]
 pub enum EventKind {
     Creation(SpawnKind),
     Move(MoveState, PostMoveAction),
@@ -77,6 +83,7 @@ pub enum EventKind {
     StatusAdded(StatusKind),
     StatusRemoved(StatusKind),
     StatusExpired(StatusKind),
+    LogScrolled(LogDirection),
 }
 
 pub type EventCallback = fn(ecs: &mut World, kind: EventKind, target: Option<Entity>) -> ();

--- a/src/clash/log.rs
+++ b/src/clash/log.rs
@@ -21,11 +21,7 @@ impl Log {
         }
         // Take as many items as you can before hitting the end
         let length = cmp::min(index + length, self.logs.len()) - index;
-        if length == 1 {
-            &self.logs[index..index + 1]
-        } else {
-            &self.logs[index..index + length]
-        }
+        &self.logs[index..index + length]
     }
 
     pub fn add(&mut self, entry: &str) {

--- a/src/clash/log.rs
+++ b/src/clash/log.rs
@@ -6,7 +6,7 @@ pub const LOG_COUNT: usize = 9;
 
 #[derive(Deserialize, Serialize, Clone)]
 pub struct Log {
-    logs: Vec<String>,
+    pub logs: Vec<String>,
     pub index: usize,
 }
 
@@ -15,18 +15,9 @@ impl Log {
         Log { logs: vec![], index: 0 }
     }
 
-    pub fn get(&self, index: usize, length: usize) -> &[String] {
-        if length == 0 || index >= self.logs.len() {
-            return &[];
-        }
-        // Take as many items as you can before hitting the end
-        let length = cmp::min(index + length, self.logs.len()) - index;
-        &self.logs[index..index + length]
-    }
-
     pub fn add(&mut self, entry: &str) {
         self.logs.push(entry.to_string());
-        self.index = self.clamp_index(self.logs.len() as i64 - LOG_COUNT as i64);
+        self.index = self.logs.len() - 1;
     }
 
     pub fn scroll_back(&mut self) {
@@ -50,65 +41,18 @@ impl Log {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn normal_get() {
-        let log = Log {
-            logs: vec!["1".to_string(), "2".to_string(), "3".to_string()],
-            index: 0,
-        };
-        let output = log.get(0, 5);
-        assert_eq!(output.len(), 3);
-        let output = log.get(2, 1);
-        assert_eq!(output.len(), 1);
-        assert_eq!(output[0], "3".to_string());
-        let output = log.get(1, 2);
-        assert_eq!(output.len(), 2);
-        assert_eq!(output[1], "3".to_string());
-    }
-
-    #[test]
-    fn get_zero() {
-        let log = Log {
-            logs: vec!["1".to_string(), "2".to_string(), "3".to_string()],
-            index: 0,
-        };
-        let output = log.get(2, 0);
-        assert_eq!(output.len(), 0);
-    }
-
-    #[test]
-    fn out_of_range() {
-        let log = Log {
-            logs: vec!["1".to_string(), "2".to_string(), "3".to_string()],
-            index: 0,
-        };
-        let output = log.get(4, 1);
-        assert_eq!(output.len(), 0);
-    }
-
-    #[test]
-    fn get_too_far() {
-        let log = Log {
-            logs: vec!["1".to_string(), "2".to_string(), "3".to_string()],
-            index: 0,
-        };
-        let output = log.get(2, 3);
-        assert_eq!(output.len(), 1);
-    }
-
     #[test]
     fn add_can_bump_index() {
         let mut log = Log::init();
-        for _ in 0..LOG_COUNT {
+        for i in 0..LOG_COUNT {
             log.add("Test");
-            assert_eq!(log.index, 0);
+            assert_eq!(log.index, i);
         }
         log.add("Test");
-        assert_eq!(log.index, 1);
+        assert_eq!(log.index, LOG_COUNT);
         log.index = 0;
         log.add("Test");
-        assert_eq!(log.index, 2);
+        assert_eq!(log.index, LOG_COUNT + 1);
     }
 
     #[test]

--- a/src/clash/log.rs
+++ b/src/clash/log.rs
@@ -12,12 +12,29 @@ impl Log {
         Log { logs: vec![] }
     }
 
-    pub fn add(&mut self, entry: &str) {
+    fn add(&mut self, entry: &str) {
         self.logs.push(entry.to_string());
     }
 
     #[cfg(test)]
     pub fn contains_count(&self, value: &str) -> usize {
         self.logs.iter().filter(|x| x.contains(value)).count()
+    }
+}
+
+use super::{EventCoordinator, EventKind, LogComponent, LogDirection};
+use specs::prelude::*;
+
+pub trait Logger {
+    fn log<T: AsRef<str>>(&mut self, message: T);
+}
+
+impl Logger for World {
+    fn log<T: AsRef<str>>(&mut self, message: T) {
+        {
+            let log = &mut self.write_resource::<LogComponent>().log;
+            log.add(message.as_ref());
+        }
+        self.raise_event(EventKind::LogScrolled(LogDirection::SnapToEnd), None);
     }
 }

--- a/src/clash/log.rs
+++ b/src/clash/log.rs
@@ -1,5 +1,3 @@
-use std::cmp;
-
 use serde::{Deserialize, Serialize};
 
 pub const LOG_COUNT: usize = 9;
@@ -7,83 +5,19 @@ pub const LOG_COUNT: usize = 9;
 #[derive(Deserialize, Serialize, Clone)]
 pub struct Log {
     pub logs: Vec<String>,
-    pub index: usize,
 }
 
 impl Log {
     pub fn init() -> Log {
-        Log { logs: vec![], index: 0 }
+        Log { logs: vec![] }
     }
 
     pub fn add(&mut self, entry: &str) {
         self.logs.push(entry.to_string());
-        self.index = self.logs.len() - 1;
-    }
-
-    pub fn scroll_back(&mut self) {
-        self.index = self.clamp_index(self.index as i64 - LOG_COUNT as i64);
-    }
-
-    pub fn scroll_forward(&mut self) {
-        self.index = self.clamp_index(self.index as i64 + LOG_COUNT as i64);
-    }
-
-    fn clamp_index(&self, index: i64) -> usize {
-        cmp::min(cmp::max(index, 0) as usize, self.logs.len() - 1)
     }
 
     #[cfg(test)]
     pub fn contains_count(&self, value: &str) -> usize {
         self.logs.iter().filter(|x| x.contains(value)).count()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    #[test]
-    fn add_can_bump_index() {
-        let mut log = Log::init();
-        for i in 0..LOG_COUNT {
-            log.add("Test");
-            assert_eq!(log.index, i);
-        }
-        log.add("Test");
-        assert_eq!(log.index, LOG_COUNT);
-        log.index = 0;
-        log.add("Test");
-        assert_eq!(log.index, LOG_COUNT + 1);
-    }
-
-    #[test]
-    fn scroll_forward() {
-        let mut log = Log::init();
-        for _ in 0..15 {
-            log.add("Test");
-        }
-        log.index = 0;
-        log.scroll_forward();
-        assert_eq!(log.index, LOG_COUNT);
-
-        for _ in 0..5 {
-            log.scroll_forward();
-        }
-        assert_eq!(log.index, log.logs.len() - 1);
-    }
-
-    #[test]
-    fn scroll_back() {
-        let mut log = Log::init();
-        for _ in 0..15 {
-            log.add("Test");
-        }
-        log.index = 14;
-        log.scroll_back();
-        assert_eq!(log.index, 14 - LOG_COUNT);
-
-        for _ in 0..5 {
-            log.scroll_back();
-        }
-        assert_eq!(log.index, 0);
     }
 }

--- a/src/clash/temperature.rs
+++ b/src/clash/temperature.rs
@@ -82,11 +82,11 @@ fn check_temperature_state(ecs: &mut World, target: &Entity) {
     let did_freeze = StatusStore::toggle_trait_from(ecs, target, StatusKind::Frozen, ecs.get_temperature(target).is_freezing());
 
     if did_freeze {
-        ecs.log(format!("{} freezes over", ecs.get_name(target).unwrap()));
+        ecs.log(format!("{} freezes over.", ecs.get_name(target).unwrap()));
     }
 
     if ecs.get_temperature(target).is_burning() && !ecs.has_status(target, StatusKind::Burning) {
-        ecs.log(format!("{} begins to burn", ecs.get_name(target).unwrap()));
+        ecs.log(format!("{} begins to burn.", ecs.get_name(target).unwrap()));
         ecs.add_status(target, StatusKind::Burning, BURN_DURATION);
     }
 }
@@ -147,7 +147,7 @@ pub fn temp_event(ecs: &mut World, kind: EventKind, target: Option<Entity>) {
                 if ecs.get_temperature(&target.unwrap()).is_burning() {
                     ecs.add_status(&target.unwrap(), StatusKind::Burning, BURN_DURATION);
                 } else {
-                    ecs.log(format!("{} stops burning", ecs.get_name(&target.unwrap()).unwrap()));
+                    ecs.log(format!("{} stops burning.", ecs.get_name(&target.unwrap()).unwrap()));
                 }
 
                 const TEMPERATURE_DAMAGE_PER_TICK: u32 = 2;


### PR DESCRIPTION
- Write a simple text rendering system that can do three things:
   - Layout test such that we can wrap correctly
   - Layout images inline (for symbols)
   - Layout "links" for use later
- Move scroll position to UI, since it is not possible to know the vert size of a line since it can now wrap.
- Part of https://github.com/chamons/ArenaGS/issues/219