### PR TITLE
Combat is hard - Lets go shopping!

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
     "cSpell.ignoreWords": [
+        "armorshop",
+        "armorshop mv",
         "cashout",
         "cashout influence",
         "chronowatch",
@@ -17,6 +19,7 @@
         "keymod",
         "knockback",
         "lifebar",
+        "mv",
         "regen",
         "rgba",
         "rustc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,7 @@ dependencies = [
  "ordered-float",
  "rand 0.7.3",
  "regex",
+ "roman",
  "sdl2",
  "sentry",
  "serde",
@@ -1343,6 +1344,12 @@ dependencies = [
  "web-sys",
  "winreg",
 ]
+
+[[package]]
+name = "roman"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c543f0c827ae24df93159810fd4bce2d0abe3785bb4c4d68fae3c467d58d9b"
 
 [[package]]
 name = "rustc-demangle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ bitflags = "1.2.1"
 regex = "1.3.9"
 sentry = { version = "*", optional = true }
 itertools = "0.9.0"
+roman = "0.1.6"
 
 [build-dependencies]
 winres = "0.1.11"

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,2 @@
-- Add special skill nodes to do
 - Add single use extension for each kind
 - Clippy and PR

--- a/TODO.md
+++ b/TODO.md
@@ -1,2 +1,0 @@
-- Add single use extension for each kind
-- Clippy and PR

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,3 @@
-- Add equipment extension in model
 - Add special skill nodes to do
 - Add single use extension for each kind
 - Clippy and PR

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,6 @@
+- Finish sales tests
+- Move merchant_view to use sales
+- Add equipment extension in model
+- Add special skill nodes to do
+- Add single use extension for each kind
+- Clippy and PR

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,3 @@
-- Finish sales tests
-- Move merchant_view to use sales
 - Add equipment extension in model
 - Add special skill nodes to do
 - Add single use extension for each kind

--- a/src/arena/battle_scene.rs
+++ b/src/arena/battle_scene.rs
@@ -217,7 +217,7 @@ impl Scene for BattleScene {
     }
 
     fn handle_mouse_click(&mut self, x: i32, y: i32, button: Option<MouseButton>) {
-        if self.help.handle_mouse_event(&self.ecs, x, y, button, &self.views) {
+        if self.help.handle_mouse_event(&mut self.ecs, x, y, button, &self.views) {
             return;
         }
 

--- a/src/clash/content/gunslinger.rs
+++ b/src/clash/content/gunslinger.rs
@@ -14,9 +14,11 @@ pub fn get_skill_tree(equipment: &EquipmentResource) -> Vec<SkillTreeNode> {
     }
 
     vec![
-        SkillTreeNode::init(equipment.get("Adjustable Sight"), skill_pos(0, 6), 0, &[]),
-        SkillTreeNode::init(equipment.get("Recoil Spring"), skill_pos(1, 6), 0, &["Adjustable Sight"]),
-        SkillTreeNode::init(equipment.get("Stippled Grip"), skill_pos(2, 5), 0, &["Recoil Spring"]),
+        SkillTreeNode::with_equipment(equipment.get("Adjustable Sight"), skill_pos(0, 6), 0, &[]),
+        SkillTreeNode::with_equipment(equipment.get("Recoil Spring"), skill_pos(1, 6), 0, &["Adjustable Sight"]),
+        SkillTreeNode::with_equipment(equipment.get("Stippled Grip"), skill_pos(2, 5), 0, &["Recoil Spring"]),
+        SkillTreeNode::with_expansion(EquipmentKinds::Weapon, 1, skill_pos(0, 8), 0, &[]),
+        SkillTreeNode::with_expansion(EquipmentKinds::Weapon, 2, skill_pos(1, 8), 0, &["Weapon Expansion"]),
     ]
 }
 

--- a/src/clash/new_game.rs
+++ b/src/clash/new_game.rs
@@ -159,6 +159,8 @@ pub fn create_intermission_state(battle_state: &World, reward: Option<RewardsCom
     ecs.insert(crate::props::MousePositionComponent::init());
     // So we can query if one exists
     ecs.register::<PlayerComponent>();
+    // For merchant and other RNG
+    ecs.insert(RandomComponent::init());
 
     // Load all skills & equipment for help
     // If we are move to a game round these will be overwritten

--- a/src/clash/progression.rs
+++ b/src/clash/progression.rs
@@ -2,6 +2,7 @@ pub mod embattle;
 mod equipment;
 pub mod gambler;
 mod progression_component;
+pub mod sales;
 mod skill_tree;
 
 pub use equipment::*;

--- a/src/clash/progression/equipment.rs
+++ b/src/clash/progression/equipment.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::iter;
 
 use serde::{Deserialize, Serialize};
@@ -65,13 +65,7 @@ impl EquipmentItem {
 
     pub fn description(&self) -> Vec<String> {
         let mut description = vec![];
-        for e in &[
-            EquipmentEffect::UnlocksAbilityClass("Aimed Shot".to_string()),
-            EquipmentEffect::ModifiesResourceTotal(-2, "Bullets".to_string()),
-            EquipmentEffect::ModifiesArmor(1),
-        ]
-        /*self.effect*/
-        {
+        for e in &self.effect {
             match e {
                 EquipmentEffect::None => {}
                 EquipmentEffect::UnlocksAbilityClass(kind) => description.push(format!("Unlocks {}.", kind)),
@@ -97,6 +91,7 @@ pub struct Equipment {
     armor: Vec<Option<EquipmentItem>>,
     accessory: Vec<Option<EquipmentItem>>,
     mastery: Vec<Option<EquipmentItem>>,
+    store_extensions: HashSet<EquipmentItem>,
 }
 
 #[allow(dead_code)]
@@ -111,6 +106,7 @@ impl Equipment {
             armor: iter::repeat(None).take(armor_slots as usize).collect(),
             accessory: iter::repeat(None).take(accessory_slots as usize).collect(),
             mastery: iter::repeat(None).take(mastery_slots as usize).collect(),
+            store_extensions: HashSet::new(),
         }
     }
 
@@ -200,6 +196,8 @@ impl Equipment {
     pub fn has(&self, name: &str) -> bool {
         self.find(name).is_some()
     }
+
+    pub fn extend(&mut self, kind: EquipmentKinds, store: bool) {}
 }
 
 #[derive(Clone)] // NotConvertSaveload
@@ -343,4 +341,11 @@ mod tests {
         assert!(equipment.has("Armor2"));
         assert_eq!(false, equipment.has("Foo"));
     }
+
+    #[test]
+    fn extend() {}
+
+    fn extend_store_only_once() {}
+
+    fn has_store_extension() {}
 }

--- a/src/clash/progression/equipment.rs
+++ b/src/clash/progression/equipment.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::iter;
 
 use serde::{Deserialize, Serialize};

--- a/src/clash/progression/equipment.rs
+++ b/src/clash/progression/equipment.rs
@@ -91,7 +91,6 @@ pub struct Equipment {
     armor: Vec<Option<EquipmentItem>>,
     accessory: Vec<Option<EquipmentItem>>,
     mastery: Vec<Option<EquipmentItem>>,
-    store_extensions: HashSet<EquipmentKinds>,
 }
 
 #[allow(dead_code)]
@@ -106,7 +105,6 @@ impl Equipment {
             armor: iter::repeat(None).take(armor_slots as usize).collect(),
             accessory: iter::repeat(None).take(accessory_slots as usize).collect(),
             mastery: iter::repeat(None).take(mastery_slots as usize).collect(),
-            store_extensions: HashSet::new(),
         }
     }
 
@@ -197,18 +195,9 @@ impl Equipment {
         self.find(name).is_some()
     }
 
-    pub fn extend(&mut self, kind: EquipmentKinds, from_store: bool) {
-        if !from_store || !self.store_extensions.contains(&kind) {
-            let store = self.get_mut_store(kind);
-            store.resize(store.len() + 1, None);
-            if from_store {
-                self.store_extensions.insert(kind);
-            }
-        }
-    }
-
-    pub fn store_extensions(&self) -> Vec<&EquipmentKinds> {
-        self.store_extensions.iter().collect()
+    pub fn extend(&mut self, kind: EquipmentKinds) {
+        let store = self.get_mut_store(kind);
+        store.resize(store.len() + 1, None);
     }
 }
 
@@ -358,29 +347,9 @@ mod tests {
     fn extend() {
         let mut equipment = Equipment::init(4, 3, 2, 1);
 
-        equipment.extend(EquipmentKinds::Accessory, false);
+        equipment.extend(EquipmentKinds::Accessory);
         assert_eq!(3, equipment.count(EquipmentKinds::Accessory));
-        equipment.extend(EquipmentKinds::Accessory, true);
+        equipment.extend(EquipmentKinds::Accessory);
         assert_eq!(4, equipment.count(EquipmentKinds::Accessory));
-    }
-
-    #[test]
-    fn extend_store_only_once() {
-        let mut equipment = Equipment::init(4, 3, 2, 1);
-
-        equipment.extend(EquipmentKinds::Accessory, true);
-        assert_eq!(3, equipment.count(EquipmentKinds::Accessory));
-        equipment.extend(EquipmentKinds::Accessory, true);
-        assert_eq!(3, equipment.count(EquipmentKinds::Accessory));
-    }
-
-    #[test]
-    fn has_store_extension() {
-        let mut equipment = Equipment::init(4, 3, 2, 1);
-
-        assert_eq!(0, equipment.store_extensions().len());
-        equipment.extend(EquipmentKinds::Accessory, true);
-        assert_eq!(3, equipment.count(EquipmentKinds::Accessory));
-        assert_eq!(1, equipment.store_extensions().len());
     }
 }

--- a/src/clash/progression/gambler.rs
+++ b/src/clash/progression/gambler.rs
@@ -30,7 +30,10 @@ pub fn get_reward_request(ecs: &World, count: u32) -> Vec<(EquipmentRarity, u32)
 }
 
 pub fn get_merchant_items(ecs: &World) -> Vec<EquipmentItem> {
-    vec![]
+    get_random_items(
+        ecs,
+        vec![(EquipmentRarity::Rare, 1), (EquipmentRarity::Uncommon, 2), (EquipmentRarity::Common, 5)],
+    )
 }
 
 pub fn get_random_items(ecs: &World, requests: Vec<(EquipmentRarity, u32)>) -> Vec<EquipmentItem> {

--- a/src/clash/progression/gambler.rs
+++ b/src/clash/progression/gambler.rs
@@ -29,6 +29,10 @@ pub fn get_reward_request(ecs: &World, count: u32) -> Vec<(EquipmentRarity, u32)
     requests.iter().map(|x| (*x.0, *x.1)).collect()
 }
 
+pub fn get_merchant_items(ecs: &World) -> Vec<EquipmentItem> {
+    vec![]
+}
+
 pub fn get_random_items(ecs: &World, requests: Vec<(EquipmentRarity, u32)>) -> Vec<EquipmentItem> {
     let equipment = ecs.read_resource::<EquipmentResource>();
     let progression = ecs.read_resource::<ProgressionComponent>();

--- a/src/clash/progression/progression_component.rs
+++ b/src/clash/progression/progression_component.rs
@@ -25,6 +25,7 @@ pub struct ProgressionState {
     pub phase: u32,
     pub influence: u32,
     pub items: HashSet<String>,
+    pub equipment_expansions: HashSet<String>,
     pub weapon: CharacterWeaponKind,
     pub equipment: Equipment,
 }
@@ -39,8 +40,13 @@ impl ProgressionState {
             phase,
             influence,
             items: items.iter().map(|s| s.to_string()).collect(),
+            equipment_expansions: HashSet::new(),
             weapon,
             equipment,
         }
+    }
+
+    pub fn has_unlock(&self, name: &str) -> bool {
+        self.items.contains(name) || self.equipment_expansions.contains(name)
     }
 }

--- a/src/clash/progression/sales.rs
+++ b/src/clash/progression/sales.rs
@@ -1,0 +1,59 @@
+use specs::prelude::*;
+
+use crate::clash::{EquipmentItem, EquipmentRarity, ProgressionComponent};
+
+fn selection_cost(equip: &EquipmentItem) -> u32 {
+    match equip.rarity {
+        EquipmentRarity::Standard => panic!("Standard should never be found in merchant"),
+        EquipmentRarity::Common => 20,
+        EquipmentRarity::Uncommon => 50,
+        EquipmentRarity::Rare => 100,
+    }
+}
+
+fn can_purchase_selection<'a>(ecs: &'a World, selection: Option<u32>, get_equipment: &impl Fn(u32) -> &'a EquipmentItem) -> bool {
+    if let Some(selection) = selection {
+        let cost = selection_cost(get_equipment(selection));
+        let influence = (*ecs.read_resource::<ProgressionComponent>()).state.influence;
+        influence >= cost
+    } else {
+        false
+    }
+}
+
+fn purchase_selection<'a>(ecs: &'a World, selection: Option<u32>, get_equipment: &impl Fn(u32) -> &'a EquipmentItem) {
+    if can_purchase_selection(ecs, selection, get_equipment) {
+        let progression = &mut ecs.write_resource::<ProgressionComponent>();
+        let equip = get_equipment(selection.unwrap());
+        progression.state.items.insert(equip.name.to_string());
+        progression.state.influence -= selection_cost(equip);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::clash::{test_helpers::*, EquipmentEffect, EquipmentItem, EquipmentKinds};
+
+    #[test]
+    fn get_equip_cost() {
+        assert_eq!(
+            20,
+            selection_cost(&EquipmentItem::init("a", None, EquipmentKinds::Weapon, EquipmentRarity::Common, &vec![]))
+        );
+        assert_eq!(
+            50,
+            selection_cost(&EquipmentItem::init("a", None, EquipmentKinds::Weapon, EquipmentRarity::Uncommon, &vec![]))
+        );
+        assert_eq!(
+            100,
+            selection_cost(&EquipmentItem::init("a", None, EquipmentKinds::Weapon, EquipmentRarity::Rare, &vec![]))
+        );
+    }
+
+    #[test]
+    fn can_purchase() {}
+
+    #[test]
+    fn purchase() {}
+}

--- a/src/clash/progression/sales.rs
+++ b/src/clash/progression/sales.rs
@@ -1,4 +1,4 @@
-use crate::clash::{CharacterWeaponKind, Equipment, EquipmentItem, EquipmentRarity, ProgressionComponent, ProgressionState};
+use crate::clash::{CharacterWeaponKind, Equipment, EquipmentItem, EquipmentKinds, EquipmentRarity, ProgressionComponent, ProgressionState};
 
 pub fn selection_cost(equip: &EquipmentItem) -> u32 {
     match equip.rarity {
@@ -9,17 +9,27 @@ pub fn selection_cost(equip: &EquipmentItem) -> u32 {
     }
 }
 
-pub fn can_purchase_selection<'a>(progression: &ProgressionComponent, equipment: &EquipmentItem) -> bool {
+pub fn can_purchase_selection(progression: &ProgressionComponent, equipment: &EquipmentItem) -> bool {
     let cost = selection_cost(equipment);
     let influence = progression.state.influence;
     influence >= cost
 }
 
-pub fn purchase_selection<'a>(progression: &mut ProgressionComponent, equipment: &EquipmentItem) {
+pub fn purchase_selection(progression: &mut ProgressionComponent, equipment: &EquipmentItem) {
     if can_purchase_selection(progression, equipment) {
         progression.state.items.insert(equipment.name.to_string());
         progression.state.influence -= selection_cost(equipment);
     }
+}
+
+pub fn can_purchase_expansion(progression: &ProgressionComponent) -> bool {
+    let influence = progression.state.influence;
+    influence >= 100
+}
+
+pub fn purchase_expansion(progression: &mut ProgressionComponent, kind: EquipmentKinds) {
+    progression.state.equipment_expansions.insert(format!("{:#?} Store Expansion", kind));
+    progression.state.equipment.extend(kind);
 }
 
 #[cfg(test)]

--- a/src/clash/progression/sales.rs
+++ b/src/clash/progression/sales.rs
@@ -1,4 +1,4 @@
-use crate::clash::{CharacterWeaponKind, Equipment, EquipmentItem, EquipmentKinds, EquipmentRarity, ProgressionComponent, ProgressionState};
+use crate::clash::{EquipmentItem, EquipmentKinds, EquipmentRarity, ProgressionComponent};
 
 pub fn selection_cost(equip: &EquipmentItem) -> u32 {
     match equip.rarity {

--- a/src/clash/progression/skill_tree.rs
+++ b/src/clash/progression/skill_tree.rs
@@ -77,12 +77,12 @@ pub struct SkillTree {
 impl SkillTree {
     pub fn init(nodes: &[SkillTreeNode]) -> SkillTree {
         SkillTree {
-            nodes: nodes.iter().map(|n| (n.name().clone(), n.clone())).collect(),
+            nodes: nodes.iter().map(|n| (n.name(), n.clone())).collect(),
         }
     }
 
     pub fn icons(&self) -> Vec<String> {
-        self.nodes.values().filter_map(|n| n.image().to_owned()).collect()
+        self.nodes.values().filter_map(|n| n.image()).collect()
     }
 
     pub fn all(&self, state: &ProgressionState) -> Vec<(SkillTreeNode, SkillNodeStatus)> {

--- a/src/clash/progression/skill_tree.rs
+++ b/src/clash/progression/skill_tree.rs
@@ -112,6 +112,8 @@ impl SkillTree {
     pub fn select(&self, state: &mut ProgressionState, name: &str) {
         if self.can_select(state, name) {
             let node = self.nodes.get(name).unwrap();
+
+            // We don't use sales APIs here since skill node cost != normal card cost
             state.influence -= node.cost;
 
             match node.contents {
@@ -120,7 +122,7 @@ impl SkillTree {
                 }
                 SkillTreeContents::EquipmentExpansion(kind, _) => {
                     state.equipment_expansions.insert(name.to_string());
-                    state.equipment.extend(kind, false);
+                    state.equipment.extend(kind);
                 }
             }
         }

--- a/src/clash/progression/skill_tree.rs
+++ b/src/clash/progression/skill_tree.rs
@@ -1,32 +1,65 @@
 use std::collections::HashMap;
 
-use super::{EquipmentItem, ProgressionState};
+use super::{EquipmentItem, EquipmentKinds, ProgressionState};
 use crate::atlas::prelude::*;
 
 #[derive(Hash, PartialEq, Eq, Clone, Debug)]
+pub enum SkillTreeContents {
+    Equipment(EquipmentItem),
+    EquipmentExpansion(EquipmentKinds, u32),
+}
+
+#[derive(Hash, PartialEq, Eq, Clone, Debug)]
 pub struct SkillTreeNode {
-    pub item: EquipmentItem,
+    pub contents: SkillTreeContents,
     pub position: Point,
     pub cost: u32,
     pub dependencies: Vec<String>,
 }
 
 impl SkillTreeNode {
-    pub fn init(item: EquipmentItem, position: Point, cost: u32, dependencies: &[&str]) -> SkillTreeNode {
+    pub fn with_equipment(equipment: EquipmentItem, position: Point, cost: u32, dependencies: &[&str]) -> SkillTreeNode {
         SkillTreeNode {
-            item,
+            contents: SkillTreeContents::Equipment(equipment),
             position,
             cost,
             dependencies: dependencies.iter().map(|d| d.to_string()).collect(),
         }
     }
 
-    pub fn name(&self) -> &String {
-        &self.item.name
+    pub fn with_expansion(kind: EquipmentKinds, generation: u32, position: Point, cost: u32, dependencies: &[&str]) -> SkillTreeNode {
+        SkillTreeNode {
+            contents: SkillTreeContents::EquipmentExpansion(kind, generation),
+            position,
+            cost,
+            dependencies: dependencies.iter().map(|d| d.to_string()).collect(),
+        }
     }
 
-    pub fn image(&self) -> &Option<String> {
-        &self.item.image
+    pub fn name(&self) -> String {
+        match &self.contents {
+            SkillTreeContents::Equipment(item) => item.name.to_string(),
+            SkillTreeContents::EquipmentExpansion(kind, generation) => {
+                let suffix = if *generation > 1 {
+                    format!(" {}", roman::to(*generation as i32).unwrap())
+                } else {
+                    "".to_string()
+                };
+                format!("{:#?} Expansion{}", kind, suffix)
+            }
+        }
+    }
+
+    pub fn image(&self) -> Option<String> {
+        match &self.contents {
+            SkillTreeContents::Equipment(item) => item.image.clone(),
+            SkillTreeContents::EquipmentExpansion(kind, _) => match kind {
+                EquipmentKinds::Weapon => Some("SpellBook05_09.png".to_string()),
+                EquipmentKinds::Armor => Some("SpellBook05_10.png".to_string()),
+                EquipmentKinds::Accessory => Some("SpellBook05_59.png".to_string()),
+                EquipmentKinds::Mastery => Some("SpellBook05_38.png".to_string()),
+            },
+        }
     }
 }
 
@@ -56,7 +89,7 @@ impl SkillTree {
         self.nodes
             .values()
             .map(|n| {
-                let status = if state.items.contains(n.name()) {
+                let status = if state.has_unlock(&n.name()) {
                     SkillNodeStatus::Selected
                 } else if self.can_select(state, &n.name()) {
                     SkillNodeStatus::Available
@@ -70,15 +103,26 @@ impl SkillTree {
 
     pub fn can_select(&self, state: &ProgressionState, name: &str) -> bool {
         let node = self.nodes.get(name).unwrap();
-        !state.items.contains(node.name()) && node.dependencies.iter().all(|d| state.items.contains(d)) && node.cost <= state.influence
+        let not_already_selected = !state.has_unlock(&node.name());
+        let dependencies_fulfilled = node.dependencies.iter().all(|d| state.has_unlock(d));
+        let can_afford = node.cost <= state.influence;
+        not_already_selected && dependencies_fulfilled && can_afford
     }
 
     pub fn select(&self, state: &mut ProgressionState, name: &str) {
         if self.can_select(state, name) {
             let node = self.nodes.get(name).unwrap();
-
-            state.items.insert(name.to_string());
             state.influence -= node.cost;
+
+            match node.contents {
+                SkillTreeContents::Equipment(_) => {
+                    state.items.insert(name.to_string());
+                }
+                SkillTreeContents::EquipmentExpansion(kind, _) => {
+                    state.equipment_expansions.insert(name.to_string());
+                    state.equipment.extend(kind, false);
+                }
+            }
         }
     }
 }
@@ -100,10 +144,10 @@ mod tests {
     fn all_has_selected() {
         let state = state_with_deps(0, &["Foo", "Bar"]);
         let tree = SkillTree::init(&[
-            SkillTreeNode::init(eq("Foo"), Point::init(0, 0), 0, &[]),
-            SkillTreeNode::init(eq("Bar"), Point::init(0, 0), 0, &[]),
-            SkillTreeNode::init(eq("Buzz"), Point::init(0, 0), 0, &[]),
-            SkillTreeNode::init(eq("Moo"), Point::init(0, 0), 100, &[]),
+            SkillTreeNode::with_equipment(eq("Foo"), Point::init(0, 0), 0, &[]),
+            SkillTreeNode::with_equipment(eq("Bar"), Point::init(0, 0), 0, &[]),
+            SkillTreeNode::with_equipment(eq("Buzz"), Point::init(0, 0), 0, &[]),
+            SkillTreeNode::with_equipment(eq("Moo"), Point::init(0, 0), 100, &[]),
         ]);
         let all = tree.all(&state);
         assert_eq!(SkillNodeStatus::Selected, all.iter().find(|&a| a.0.name() == "Foo").unwrap().1);
@@ -116,9 +160,9 @@ mod tests {
     fn can_select_dependencies() {
         let mut state = state_with_deps(0, &[]);
         let tree = SkillTree::init(&[
-            SkillTreeNode::init(eq("Foo"), Point::init(0, 0), 0, &[]),
-            SkillTreeNode::init(eq("Bar"), Point::init(0, 0), 0, &["Foo"]),
-            SkillTreeNode::init(eq("Buzz"), Point::init(0, 0), 0, &["Bar"]),
+            SkillTreeNode::with_equipment(eq("Foo"), Point::init(0, 0), 0, &[]),
+            SkillTreeNode::with_equipment(eq("Bar"), Point::init(0, 0), 0, &["Foo"]),
+            SkillTreeNode::with_equipment(eq("Buzz"), Point::init(0, 0), 0, &["Bar"]),
         ]);
         assert!(tree.can_select(&state, "Foo"));
         assert_eq!(false, tree.can_select(&state, "Bar"));
@@ -134,10 +178,10 @@ mod tests {
     fn can_select_cost() {
         let mut state = state_with_deps(0, &[]);
         let tree = SkillTree::init(&[
-            SkillTreeNode::init(eq("Foo"), Point::init(0, 0), 5, &[]),
-            SkillTreeNode::init(eq("Bazz"), Point::init(0, 0), 10, &[]),
-            SkillTreeNode::init(eq("Bar"), Point::init(0, 0), 5, &["Foo"]),
-            SkillTreeNode::init(eq("Buzz"), Point::init(0, 0), 0, &["Bar"]),
+            SkillTreeNode::with_equipment(eq("Foo"), Point::init(0, 0), 5, &[]),
+            SkillTreeNode::with_equipment(eq("Bazz"), Point::init(0, 0), 10, &[]),
+            SkillTreeNode::with_equipment(eq("Bar"), Point::init(0, 0), 5, &["Foo"]),
+            SkillTreeNode::with_equipment(eq("Buzz"), Point::init(0, 0), 0, &["Bar"]),
         ]);
         assert_eq!(false, tree.can_select(&state, "Foo"));
         assert_eq!(false, tree.can_select(&state, "Bazz"));
@@ -155,10 +199,10 @@ mod tests {
     fn select() {
         let mut state = state_with_deps(7, &[]);
         let tree = SkillTree::init(&[
-            SkillTreeNode::init(eq("Foo"), Point::init(0, 0), 5, &[]),
-            SkillTreeNode::init(eq("Bazz"), Point::init(0, 0), 10, &[]),
-            SkillTreeNode::init(eq("Bar"), Point::init(0, 0), 5, &["Foo"]),
-            SkillTreeNode::init(eq("Buzz"), Point::init(0, 0), 0, &["Bar"]),
+            SkillTreeNode::with_equipment(eq("Foo"), Point::init(0, 0), 5, &[]),
+            SkillTreeNode::with_equipment(eq("Bazz"), Point::init(0, 0), 10, &[]),
+            SkillTreeNode::with_equipment(eq("Bar"), Point::init(0, 0), 5, &["Foo"]),
+            SkillTreeNode::with_equipment(eq("Buzz"), Point::init(0, 0), 0, &["Bar"]),
         ]);
 
         tree.select(&mut state, "Foo");
@@ -170,15 +214,49 @@ mod tests {
     fn select_already_selected() {
         let mut state = state_with_deps(10, &[]);
         let tree = SkillTree::init(&[
-            SkillTreeNode::init(eq("Foo"), Point::init(0, 0), 5, &[]),
-            SkillTreeNode::init(eq("Bazz"), Point::init(0, 0), 10, &[]),
-            SkillTreeNode::init(eq("Bar"), Point::init(0, 0), 5, &["Foo"]),
-            SkillTreeNode::init(eq("Buzz"), Point::init(0, 0), 0, &["Bar"]),
+            SkillTreeNode::with_equipment(eq("Foo"), Point::init(0, 0), 5, &[]),
+            SkillTreeNode::with_equipment(eq("Bazz"), Point::init(0, 0), 10, &[]),
+            SkillTreeNode::with_equipment(eq("Bar"), Point::init(0, 0), 5, &["Foo"]),
+            SkillTreeNode::with_equipment(eq("Buzz"), Point::init(0, 0), 0, &["Bar"]),
         ]);
 
         tree.select(&mut state, "Foo");
         assert_eq!(5, state.influence);
         tree.select(&mut state, "Foo");
         assert_eq!(5, state.influence);
+    }
+
+    #[test]
+    fn select_expansion() {
+        let mut state = state_with_deps(10, &[]);
+        let tree = SkillTree::init(&[
+            SkillTreeNode::with_expansion(EquipmentKinds::Armor, 1, Point::init(0, 0), 5, &[]),
+            SkillTreeNode::with_equipment(eq("Bazz"), Point::init(0, 0), 5, &["Armor Expansion"]),
+        ]);
+
+        tree.select(&mut state, "Armor Expansion");
+        assert_eq!(1, state.equipment.count(EquipmentKinds::Armor));
+        assert!(tree.can_select(&state, "Bazz"));
+    }
+
+    #[test]
+    fn select_multiple_expansions() {
+        let mut state = state_with_deps(15, &[]);
+        let tree = SkillTree::init(&[
+            SkillTreeNode::with_expansion(EquipmentKinds::Armor, 1, Point::init(0, 0), 5, &[]),
+            SkillTreeNode::with_expansion(EquipmentKinds::Armor, 2, Point::init(0, 0), 5, &["Armor Expansion"]),
+            SkillTreeNode::with_expansion(EquipmentKinds::Armor, 3, Point::init(0, 0), 5, &["Armor Expansion II"]),
+        ]);
+
+        tree.select(&mut state, "Armor Expansion");
+        assert_eq!(1, state.equipment.count(EquipmentKinds::Armor));
+        assert!(tree.can_select(&state, "Armor Expansion II"));
+
+        tree.select(&mut state, "Armor Expansion II");
+        assert_eq!(2, state.equipment.count(EquipmentKinds::Armor));
+        assert!(tree.can_select(&state, "Armor Expansion III"));
+
+        tree.select(&mut state, "Armor Expansion III");
+        assert_eq!(3, state.equipment.count(EquipmentKinds::Armor));
     }
 }

--- a/src/intermission.rs
+++ b/src/intermission.rs
@@ -2,6 +2,7 @@ mod card_view;
 mod character_scene;
 mod equipment_view;
 mod merchant_view;
+mod next_battle_view;
 mod reward_scene;
 mod skilltree_view;
 

--- a/src/intermission.rs
+++ b/src/intermission.rs
@@ -1,6 +1,7 @@
 mod card_view;
 mod character_scene;
 mod equipment_view;
+mod merchant_view;
 mod reward_scene;
 mod skilltree_view;
 

--- a/src/intermission/card_view.rs
+++ b/src/intermission/card_view.rs
@@ -166,7 +166,7 @@ impl View for CardView {
         Ok(())
     }
 
-    fn handle_mouse_click(&mut self, _ecs: &World, x: i32, y: i32, button: Option<MouseButton>) {
+    fn handle_mouse_click(&mut self, _ecs: &mut World, x: i32, y: i32, button: Option<MouseButton>) {
         if let Some(button) = button {
             if button == MouseButton::Left {
                 if self.frame.contains_point(SDLPoint::new(x, y)) {

--- a/src/intermission/character_scene.rs
+++ b/src/intermission/character_scene.rs
@@ -9,6 +9,7 @@ use sdl2::rect::Point as SDLPoint;
 use specs::prelude::*;
 
 use super::equipment_view::EquipmentView;
+use super::merchant_view::MerchantView;
 use super::skilltree_view::SkillTreeView;
 use crate::after_image::prelude::*;
 use crate::atlas::prelude::*;
@@ -36,7 +37,7 @@ impl CharacterScene {
                 text_renderer,
                 true,
                 true,
-                ButtonDelegate::init().handler(Box::new(move || *next_fight.borrow_mut() = true)),
+                ButtonDelegate::init().handler(Box::new(move |_| *next_fight.borrow_mut() = true)),
             )?,
             tab: Box::from(TabView::init(
                 SDLPoint::new(0, 0),
@@ -61,12 +62,12 @@ impl Scene for CharacterScene {
     }
 
     fn handle_mouse_click(&mut self, x: i32, y: i32, button: Option<MouseButton>) {
-        if self.help.handle_mouse_event(&self.ecs, x, y, button, slice::from_ref(&self.tab)) {
+        if self.help.handle_mouse_event(&mut self.ecs, x, y, button, slice::from_ref(&self.tab)) {
             return;
         }
 
-        self.tab.handle_mouse_click(&self.ecs, x, y, button);
-        self.continue_button.handle_mouse_click(&self.ecs, x, y, button);
+        self.tab.handle_mouse_click(&mut self.ecs, x, y, button);
+        self.continue_button.handle_mouse_click(&mut self.ecs, x, y, button);
     }
 
     fn handle_mouse_move(&mut self, x: i32, y: i32, state: MouseState) {

--- a/src/intermission/character_scene.rs
+++ b/src/intermission/character_scene.rs
@@ -15,7 +15,7 @@ use super::skilltree_view::SkillTreeView;
 use crate::after_image::prelude::*;
 use crate::atlas::prelude::*;
 use crate::conductor::{Scene, StageDirection};
-use crate::props::{Button, ButtonDelegate, EmptyView, HelpPopup, TabInfo, TabView, View};
+use crate::props::{HelpPopup, TabInfo, TabView, View};
 
 pub struct CharacterScene {
     next_fight: Rc<RefCell<bool>>,

--- a/src/intermission/character_scene.rs
+++ b/src/intermission/character_scene.rs
@@ -13,7 +13,7 @@ use super::skilltree_view::SkillTreeView;
 use crate::after_image::prelude::*;
 use crate::atlas::prelude::*;
 use crate::conductor::{Scene, StageDirection};
-use crate::props::{Button, EmptyView, HelpPopup, TabInfo, TabView, View};
+use crate::props::{Button, ButtonDelegate, EmptyView, HelpPopup, TabInfo, TabView, View};
 
 pub struct CharacterScene {
     next_fight: Rc<RefCell<bool>>,
@@ -36,17 +36,17 @@ impl CharacterScene {
                 text_renderer,
                 true,
                 true,
-                None,
-                Some(Box::new(move || *next_fight.borrow_mut() = true)),
+                ButtonDelegate::init().handler(Box::new(move || *next_fight.borrow_mut() = true)),
             )?,
             tab: Box::from(TabView::init(
                 SDLPoint::new(0, 0),
                 render_context,
                 text_renderer,
                 vec![
-                    TabInfo::init("Skill Tree", Box::new(SkillTreeView::init(render_context, text_renderer, &ecs)?), |_| true),
-                    TabInfo::init("Equipment", Box::new(EquipmentView::init(render_context, text_renderer, &ecs)?), |_| true),
-                    TabInfo::init("Store", Box::new(EmptyView::init()?), |_| true),
+                    TabInfo::init("Profession", Box::new(SkillTreeView::init(render_context, text_renderer, &ecs)?)),
+                    TabInfo::init("Equipment", Box::new(EquipmentView::init(render_context, text_renderer, &ecs)?)),
+                    TabInfo::init("Merchant", Box::new(MerchantView::init(render_context, text_renderer, &ecs)?)),
+                    TabInfo::init("Next Battle", Box::new(EmptyView::init()?)),
                 ],
             )?),
             help: HelpPopup::init(&ecs, &render_context, Rc::clone(&text_renderer))?,

--- a/src/intermission/equipment_view.rs
+++ b/src/intermission/equipment_view.rs
@@ -127,8 +127,6 @@ impl EquipmentView {
                 "Sort",
                 render_context,
                 text_renderer,
-                true,
-                true,
                 ButtonDelegate::init().handler(Box::new(move |_| *should_sort.borrow_mut() = true)),
             )?,
             slots: RefCell::new(vec![]),

--- a/src/intermission/equipment_view.rs
+++ b/src/intermission/equipment_view.rs
@@ -129,7 +129,7 @@ impl EquipmentView {
                 text_renderer,
                 true,
                 true,
-                ButtonDelegate::init().handler(Box::new(move || *should_sort.borrow_mut() = true)),
+                ButtonDelegate::init().handler(Box::new(move |_| *should_sort.borrow_mut() = true)),
             )?,
             slots: EquipmentView::create_slots(ecs, &ui),
             ui,
@@ -255,7 +255,7 @@ impl View for EquipmentView {
         Ok(())
     }
 
-    fn handle_mouse_click(&mut self, ecs: &World, x: i32, y: i32, button: Option<MouseButton>) {
+    fn handle_mouse_click(&mut self, ecs: &mut World, x: i32, y: i32, button: Option<MouseButton>) {
         for c in self.cards.borrow_mut().iter_mut().rev() {
             c.handle_mouse_click(ecs, x, y, button);
             if c.grabbed.is_some() {

--- a/src/intermission/equipment_view.rs
+++ b/src/intermission/equipment_view.rs
@@ -123,7 +123,7 @@ impl EquipmentView {
             should_sort: Rc::clone(&should_sort),
             needs_z_reorder: RefCell::new(false),
             sort: Button::text(
-                SDLPoint::new(650, 650),
+                SDLPoint::new(800, 650),
                 "Sort",
                 render_context,
                 text_renderer,

--- a/src/intermission/equipment_view.rs
+++ b/src/intermission/equipment_view.rs
@@ -217,7 +217,7 @@ impl EquipmentView {
         }
     }
 
-    fn find_slot_at(x: i32, y: i32, slots: &Vec<EquipmentSlotView>) -> Option<usize> {
+    fn find_slot_at(x: i32, y: i32, slots: &[EquipmentSlotView]) -> Option<usize> {
         slots.iter().position(|s| s.frame.contains_point(SDLPoint::new(x, y)))
     }
 }

--- a/src/intermission/equipment_view.rs
+++ b/src/intermission/equipment_view.rs
@@ -13,7 +13,7 @@ use super::card_view::{CardView, CARD_HEIGHT, CARD_WIDTH};
 use crate::after_image::prelude::*;
 use crate::atlas::prelude::*;
 use crate::clash::{EquipmentItem, EquipmentKinds, EquipmentResource, ProgressionComponent, ProgressionState};
-use crate::props::{Button, HitTestResult, MousePositionComponent, View};
+use crate::props::{Button, ButtonDelegate, HitTestResult, MousePositionComponent, View};
 
 pub struct EquipmentSlotView {
     frame: SDLRect,
@@ -129,8 +129,7 @@ impl EquipmentView {
                 text_renderer,
                 true,
                 true,
-                None,
-                Some(Box::new(move || *should_sort.borrow_mut() = true)),
+                ButtonDelegate::init().handler(Box::new(move || *should_sort.borrow_mut() = true)),
             )?,
             slots: EquipmentView::create_slots(ecs, &ui),
             ui,

--- a/src/intermission/merchant_view.rs
+++ b/src/intermission/merchant_view.rs
@@ -55,7 +55,7 @@ impl MerchantView {
 
         let selection = Rc::new(RefCell::new(None));
         let accept_button = Button::text(
-            SDLPoint::new(780, 585),
+            SDLPoint::new(800, 650),
             "Purchase",
             &render_context,
             text_renderer,

--- a/src/intermission/merchant_view.rs
+++ b/src/intermission/merchant_view.rs
@@ -1,18 +1,17 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use sdl2::mouse::{MouseButton, MouseState};
+use sdl2::mouse::MouseButton;
 use sdl2::rect::Point as SDLPoint;
-use sdl2::rect::Rect as SDLRect;
 use specs::prelude::*;
 
-use super::card_view::{CardView, CARD_WIDTH};
-use super::reward_scene::{draw_selection_frame, get_reward, icons_for_items};
+use super::card_view::CardView;
+use super::reward_scene::{draw_selection_frame, icons_for_items};
 use crate::after_image::prelude::*;
 use crate::atlas::prelude::*;
-use crate::clash::{gambler, sales, EquipmentItem, EquipmentKinds, EquipmentRarity, EquipmentResource, ProgressionComponent, RewardsComponent};
+use crate::clash::{gambler, sales, EquipmentKinds, ProgressionComponent};
 use crate::enclose;
-use crate::props::{Button, ButtonDelegate, ButtonEnabledState, HitTestResult, View};
+use crate::props::{Button, ButtonDelegate, ButtonEnabledState, View};
 
 pub struct MerchantView {
     text_renderer: Rc<TextRenderer>,
@@ -243,9 +242,5 @@ impl View for MerchantView {
         }
 
         self.accept_button.handle_mouse_click(ecs, x, y, button);
-    }
-
-    fn hit_test(&self, ecs: &World, x: i32, y: i32) -> Option<HitTestResult> {
-        None
     }
 }

--- a/src/intermission/merchant_view.rs
+++ b/src/intermission/merchant_view.rs
@@ -18,7 +18,7 @@ pub struct MerchantView {
     text_renderer: Rc<TextRenderer>,
     ui: Rc<IconCache>,
     cards: Rc<RefCell<Vec<Option<CardView>>>>,
-    equipment_expand_buttons: Rc<RefCell<Vec<Button>>>,
+    equipment_expand_buttons: Rc<RefCell<Vec<Option<Button>>>>,
     accept_button: Button,
     selection: Rc<RefCell<Option<u32>>>,
 }
@@ -57,39 +57,11 @@ impl MerchantView {
             ))
         };
 
+        // The following code is correct, but more complex than I'd like
+        // A downside of my buttons respond in callback with rust's ownership
+        // is anything they want to touch outside of the ECS has to be Rc<RefCell>
+        // and cloned via enclose! macro. It works, but is not pretty...
         let selection = Rc::new(RefCell::new(None));
-        let accept_button = Button::text(
-            SDLPoint::new(800, 650),
-            "Purchase",
-            &render_context,
-            text_renderer,
-            ButtonDelegate::init()
-                .enabled(Box::new(enclose! { (cards, selection) move |ecs| {
-                    let cards = cards.borrow();
-
-                    if let Some(selection_index) = *selection.borrow() {
-                        let progression = &mut ecs.write_resource::<ProgressionComponent>();
-                        let selection_equip = &cards[selection_index as usize].as_ref().unwrap().equipment;
-                        if sales::can_purchase_selection (&progression, &selection_equip) {
-                            return ButtonEnabledState::Shown;
-                        }
-                    }
-                    ButtonEnabledState::Ghosted
-                }}))
-                .handler(Box::new(enclose! { (cards, selection) move |ecs| {
-                    let mut cards = cards.borrow_mut();
-                    let mut selection = selection.borrow_mut();
-                    if let Some(selection_index) = *selection {
-                        let mut progression = &mut ecs.write_resource::<ProgressionComponent>();
-                        let selection_equip = &cards[selection_index as usize].as_ref().unwrap().equipment;
-                        if sales::can_purchase_selection (&progression, &selection_equip) {
-                            sales::purchase_selection(&mut progression, &selection_equip);
-                            cards[selection_index as usize] = None;
-                            *selection = None;
-                        }
-                    }
-                }})),
-        )?;
 
         let mut equipment_expand_buttons = vec![];
         let progression = &mut ecs.read_resource::<ProgressionComponent>();
@@ -103,18 +75,86 @@ impl MerchantView {
         .filter(|k| !progression.state.equipment_expansions.contains(&format!("{:#?} Store Expansion", k)))
         .enumerate()
         {
-            equipment_expand_buttons.push(
+            equipment_expand_buttons.push(Some(
                 Button::text(
                     SDLPoint::new(50 + 155 * i as i32, 655),
                     &format!("+1 {:#?} Slot", kind),
                     render_context,
                     text_renderer,
-                    ButtonDelegate::init(),
+                    ButtonDelegate::init()
+                        .enabled(Box::new(|ecs| {
+                            let progression = ecs.read_resource::<ProgressionComponent>();
+                            if sales::can_purchase_expansion(&progression) {
+                                ButtonEnabledState::Shown
+                            } else {
+                                ButtonEnabledState::Ghosted
+                            }
+                        }))
+                        .handler(Box::new(enclose! { (selection) move |_| {
+                            *selection.borrow_mut() = Some(8 + i as u32);
+                        }})),
                 )?
                 .with_size(FontSize::Small),
-            )
+            ))
         }
         let equipment_expand_buttons = Rc::new(RefCell::new(equipment_expand_buttons));
+
+        let accept_button = Button::text(
+            SDLPoint::new(800, 650),
+            "Purchase",
+            &render_context,
+            text_renderer,
+            ButtonDelegate::init()
+                .enabled(Box::new(enclose! { (cards, selection) move |ecs| {
+                    let cards = cards.borrow();
+
+                    if let Some(selection_index) = *selection.borrow() {
+                        let progression = &mut ecs.write_resource::<ProgressionComponent>();
+                        if selection_index < 8 {
+                            let selection_equip = &cards[selection_index as usize].as_ref().unwrap().equipment;
+                            if sales::can_purchase_selection (&progression, &selection_equip) {
+                                return ButtonEnabledState::Shown;
+                            }
+                        }
+                        else {
+                            if sales::can_purchase_expansion(progression) {
+                                return ButtonEnabledState::Shown;
+                            }
+                        }
+                    }
+                    ButtonEnabledState::Ghosted
+                }}))
+                .handler(Box::new(enclose! { (cards, selection, equipment_expand_buttons) move |ecs| {
+                    let mut selection = selection.borrow_mut();
+                    if let Some(selection_index) = *selection {
+                        let mut progression = &mut ecs.write_resource::<ProgressionComponent>();
+                        if selection_index < 8 {
+                            let mut cards = cards.borrow_mut();
+                            let selection_equip = &cards[selection_index as usize].as_ref().unwrap().equipment;
+                            if sales::can_purchase_selection (&progression, &selection_equip) {
+                                sales::purchase_selection(&mut progression, &selection_equip);
+                                cards[selection_index as usize] = None;
+                            }
+                        }
+                        else {
+                            let mut equipment_expand_buttons = equipment_expand_buttons.borrow_mut();
+
+                            if sales::can_purchase_expansion(progression) {
+                                let kind_index = selection_index as usize - 8;
+                                let kind = vec![
+                                    EquipmentKinds::Weapon,
+                                    EquipmentKinds::Armor,
+                                    EquipmentKinds::Accessory,
+                                    EquipmentKinds::Mastery,
+                                ][kind_index];
+                                sales::purchase_expansion(progression, kind);
+                                equipment_expand_buttons[kind_index] = None;
+                            }
+                        }
+                        *selection = None;
+                    }
+                }})),
+        )?;
 
         Ok(MerchantView {
             text_renderer: Rc::clone(text_renderer),
@@ -130,11 +170,18 @@ impl MerchantView {
 impl View for MerchantView {
     fn render(&self, ecs: &World, canvas: &mut RenderCanvas, frame: u64) -> BoxResult<()> {
         let cards = self.cards.borrow();
+        let equipment_expand_buttons = self.equipment_expand_buttons.borrow();
 
         if let Some(selection) = *self.selection.borrow() {
-            if let Some(card) = &cards[selection as usize] {
-                draw_selection_frame(canvas, &self.ui, card.frame, "card_frame_large_selection.png")?;
-            }
+            if selection < 8 {
+                if let Some(card) = &cards[selection as usize] {
+                    draw_selection_frame(canvas, &self.ui, card.frame, "card_frame_large_selection.png")?;
+                }
+            } else {
+                if let Some(button) = &equipment_expand_buttons[selection as usize - 8] {
+                    draw_selection_frame(canvas, &self.ui, button.frame, "button_frame_full_selection.png")?;
+                }
+            };
         }
 
         for c in cards.iter().flatten() {
@@ -151,7 +198,7 @@ impl View for MerchantView {
             )?;
         }
 
-        for b in self.equipment_expand_buttons.borrow().iter() {
+        for b in equipment_expand_buttons.iter().flatten() {
             b.render(ecs, canvas, frame)?;
 
             self.text_renderer.render_text_centered(
@@ -190,10 +237,13 @@ impl View for MerchantView {
                 }
             }
         }
+
+        for b in self.equipment_expand_buttons.borrow_mut().iter_mut().flatten() {
+            b.handle_mouse_click(ecs, x, y, button);
+        }
+
         self.accept_button.handle_mouse_click(ecs, x, y, button);
     }
-
-    fn handle_mouse_move(&mut self, ecs: &World, x: i32, y: i32, state: MouseState) {}
 
     fn hit_test(&self, ecs: &World, x: i32, y: i32) -> Option<HitTestResult> {
         None

--- a/src/intermission/merchant_view.rs
+++ b/src/intermission/merchant_view.rs
@@ -62,10 +62,7 @@ impl MerchantView {
             "Purchase",
             &render_context,
             text_renderer,
-            true,
-            true,
             ButtonDelegate::init()
-                .handler(Box::new(move |_| {}))
                 .enabled(Box::new(enclose! { (cards, selection) move |ecs| {
                     let cards = cards.borrow();
 

--- a/src/intermission/merchant_view.rs
+++ b/src/intermission/merchant_view.rs
@@ -1,0 +1,79 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use sdl2::mouse::{MouseButton, MouseState};
+use sdl2::rect::Point as SDLPoint;
+use specs::prelude::*;
+
+use super::card_view::{CardView, CARD_WIDTH};
+use super::reward_scene::{get_reward, icons_for_items};
+use crate::after_image::prelude::*;
+use crate::atlas::prelude::*;
+use crate::clash::{gambler, EquipmentItem, EquipmentResource, RewardsComponent};
+use crate::enclose;
+use crate::props::{Button, ButtonDelegate, ButtonEnabledState, HitTestResult, View};
+
+pub struct MerchantView {
+    text_renderer: Rc<TextRenderer>,
+    reward: RewardsComponent,
+    ui: Rc<IconCache>,
+    cards: Vec<CardView>,
+    accept_button: Button,
+    selection: Rc<RefCell<Option<u32>>>,
+}
+
+impl MerchantView {
+    pub fn init(render_context: &RenderContext, text_renderer: &Rc<TextRenderer>, ecs: &World) -> BoxResult<MerchantView> {
+        let reward = get_reward(ecs);
+        let items = gambler::get_merchant_items(ecs);
+        let icons = icons_for_items(render_context, &items)?;
+
+        let ui = Rc::new(IconCache::init(
+            &render_context,
+            IconLoader::init_ui(),
+            &[
+                "card_frame_large.png",
+                "card_frame_large_selection.png",
+                "button_frame_full_selection.png",
+                "reward_background.png",
+            ],
+        )?);
+
+        let cards = vec![];
+        let selection = Rc::new(RefCell::new(None));
+        let accept_button = Button::text(
+            SDLPoint::new(780, 585),
+            "Purchase",
+            &render_context,
+            text_renderer,
+            true,
+            true,
+            ButtonDelegate::init().handler(Box::new(move |_| {})).enabled(Box::new(
+                enclose! { (selection) move || if selection.borrow().is_some() { ButtonEnabledState::Shown } else { ButtonEnabledState::Ghosted} },
+            )),
+        )?;
+
+        Ok(MerchantView {
+            text_renderer: Rc::clone(text_renderer),
+            ui,
+            reward,
+            cards,
+            accept_button,
+            selection: Rc::clone(&selection),
+        })
+    }
+}
+
+impl View for MerchantView {
+    fn render(&self, ecs: &World, canvas: &mut RenderCanvas, frame: u64) -> BoxResult<()> {
+        Ok(())
+    }
+
+    fn handle_mouse_click(&mut self, ecs: &mut World, x: i32, y: i32, button: Option<MouseButton>) {}
+
+    fn handle_mouse_move(&mut self, ecs: &World, x: i32, y: i32, state: MouseState) {}
+
+    fn hit_test(&self, ecs: &World, x: i32, y: i32) -> Option<HitTestResult> {
+        None
+    }
+}

--- a/src/intermission/merchant_view.rs
+++ b/src/intermission/merchant_view.rs
@@ -3,13 +3,14 @@ use std::rc::Rc;
 
 use sdl2::mouse::{MouseButton, MouseState};
 use sdl2::rect::Point as SDLPoint;
+use sdl2::rect::Rect as SDLRect;
 use specs::prelude::*;
 
 use super::card_view::{CardView, CARD_WIDTH};
 use super::reward_scene::{draw_selection_frame, get_reward, icons_for_items};
 use crate::after_image::prelude::*;
 use crate::atlas::prelude::*;
-use crate::clash::{gambler, EquipmentItem, EquipmentResource, RewardsComponent};
+use crate::clash::{gambler, EquipmentItem, EquipmentRarity, EquipmentResource, ProgressionComponent, RewardsComponent};
 use crate::enclose;
 use crate::props::{Button, ButtonDelegate, ButtonEnabledState, HitTestResult, View};
 
@@ -40,7 +41,7 @@ impl MerchantView {
                 .enumerate()
                 .map(|(i, s)| {
                     CardView::init(
-                        SDLPoint::new(100 + ((i % 4) * 200) as i32, 100 + ((i / 4) * 275) as i32),
+                        SDLPoint::new(120 + ((i % 4) * 200) as i32, 90 + ((i / 4) * 275) as i32),
                         text_renderer,
                         &ui,
                         &icons,
@@ -85,9 +86,36 @@ impl View for MerchantView {
 
         for c in &self.cards {
             c.render(ecs, canvas, frame)?;
+
+            let cost = match c.equipment.rarity {
+                EquipmentRarity::Standard => panic!("Standard should never be found in merchant"),
+                EquipmentRarity::Common => 20,
+                EquipmentRarity::Uncommon => 50,
+                EquipmentRarity::Rare => 100,
+            };
+
+            self.text_renderer.render_text_centered(
+                &format!("{} Influence", cost),
+                c.frame.x(),
+                c.frame.y() - 20,
+                c.frame.width(),
+                canvas,
+                FontSize::Bold,
+                FontColor::Brown,
+            )?;
         }
 
         self.accept_button.render(&ecs, canvas, frame)?;
+
+        let progression = &(*ecs.read_resource::<ProgressionComponent>()).state;
+        self.text_renderer.render_text(
+            &format!("Current Influence: {}", progression.influence),
+            780,
+            615,
+            canvas,
+            FontSize::Bold,
+            FontColor::Brown,
+        )?;
 
         Ok(())
     }

--- a/src/intermission/merchant_view.rs
+++ b/src/intermission/merchant_view.rs
@@ -201,7 +201,7 @@ impl View for MerchantView {
             b.render(ecs, canvas, frame)?;
 
             self.text_renderer.render_text_centered(
-                &format!("100 Influence"),
+                "100 Influence",
                 b.frame.x(),
                 b.frame.y() - 20,
                 b.frame.width(),

--- a/src/intermission/next_battle_view.rs
+++ b/src/intermission/next_battle_view.rs
@@ -5,13 +5,10 @@ use sdl2::mouse::{MouseButton, MouseState};
 use sdl2::rect::Point as SDLPoint;
 use specs::prelude::*;
 
-use super::card_view::{CardView, CARD_WIDTH};
-use super::reward_scene::{draw_selection_frame, get_reward, icons_for_items};
 use crate::after_image::prelude::*;
 use crate::atlas::prelude::*;
-use crate::clash::{gambler, EquipmentItem, EquipmentResource, RewardsComponent};
 use crate::enclose;
-use crate::props::{Button, ButtonDelegate, ButtonEnabledState, HitTestResult, View};
+use crate::props::{Button, ButtonDelegate, View};
 
 pub struct NextBattleView {
     continue_button: Button,
@@ -43,9 +40,5 @@ impl View for NextBattleView {
 
     fn handle_mouse_move(&mut self, ecs: &World, x: i32, y: i32, state: MouseState) {
         self.continue_button.handle_mouse_move(ecs, x, y, state);
-    }
-
-    fn hit_test(&self, ecs: &World, x: i32, y: i32) -> Option<HitTestResult> {
-        None
     }
 }

--- a/src/intermission/next_battle_view.rs
+++ b/src/intermission/next_battle_view.rs
@@ -24,8 +24,6 @@ impl NextBattleView {
             "Next Fight",
             render_context,
             text_renderer,
-            true,
-            true,
             ButtonDelegate::init().handler(Box::new(enclose! { (next_fight) move |_| *next_fight.borrow_mut() = true })),
         )?;
         Ok(NextBattleView { continue_button })

--- a/src/intermission/next_battle_view.rs
+++ b/src/intermission/next_battle_view.rs
@@ -1,0 +1,53 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use sdl2::mouse::{MouseButton, MouseState};
+use sdl2::rect::Point as SDLPoint;
+use specs::prelude::*;
+
+use super::card_view::{CardView, CARD_WIDTH};
+use super::reward_scene::{draw_selection_frame, get_reward, icons_for_items};
+use crate::after_image::prelude::*;
+use crate::atlas::prelude::*;
+use crate::clash::{gambler, EquipmentItem, EquipmentResource, RewardsComponent};
+use crate::enclose;
+use crate::props::{Button, ButtonDelegate, ButtonEnabledState, HitTestResult, View};
+
+pub struct NextBattleView {
+    continue_button: Button,
+}
+
+impl NextBattleView {
+    pub fn init(render_context: &RenderContext, text_renderer: &Rc<TextRenderer>, next_fight: &Rc<RefCell<bool>>) -> BoxResult<NextBattleView> {
+        let continue_button = Button::text(
+            SDLPoint::new(800, 650),
+            "Next Fight",
+            render_context,
+            text_renderer,
+            true,
+            true,
+            ButtonDelegate::init().handler(Box::new(enclose! { (next_fight) move |_| *next_fight.borrow_mut() = true })),
+        )?;
+        Ok(NextBattleView { continue_button })
+    }
+}
+
+impl View for NextBattleView {
+    fn render(&self, ecs: &World, canvas: &mut RenderCanvas, frame: u64) -> BoxResult<()> {
+        self.continue_button.render(ecs, canvas, frame)?;
+
+        Ok(())
+    }
+
+    fn handle_mouse_click(&mut self, ecs: &mut World, x: i32, y: i32, button: Option<MouseButton>) {
+        self.continue_button.handle_mouse_click(ecs, x, y, button);
+    }
+
+    fn handle_mouse_move(&mut self, ecs: &World, x: i32, y: i32, state: MouseState) {
+        self.continue_button.handle_mouse_move(ecs, x, y, state);
+    }
+
+    fn hit_test(&self, ecs: &World, x: i32, y: i32) -> Option<HitTestResult> {
+        None
+    }
+}

--- a/src/intermission/reward_scene.rs
+++ b/src/intermission/reward_scene.rs
@@ -179,11 +179,11 @@ impl Scene for RewardScene {
         }
         self.text_renderer.render_text(
             &format!("Influence Reward: {}", current_influence),
-            780,
-            550,
+            785,
+            615,
             canvas,
             FontSize::Bold,
-            FontColor::White,
+            FontColor::Brown,
         )?;
 
         self.accept_button.render(&self.ecs, canvas, frame)?;

--- a/src/intermission/reward_scene.rs
+++ b/src/intermission/reward_scene.rs
@@ -13,7 +13,7 @@ use crate::atlas::prelude::*;
 use crate::clash::{EquipmentItem, EquipmentResource, ProgressionComponent, RewardsComponent};
 use crate::conductor::{Scene, StageDirection};
 use crate::enclose;
-use crate::props::{Button, View};
+use crate::props::{Button, ButtonDelegate, View};
 
 pub struct RewardScene {
     text_renderer: Rc<TextRenderer>,
@@ -78,8 +78,9 @@ impl RewardScene {
             text_renderer,
             true,
             true,
-            Some(Box::new(enclose! { (selection) move |_| selection.borrow().is_some() })),
-            Some(Box::new(enclose! { (chosen) move || *chosen.borrow_mut() = true })),
+            ButtonDelegate::init()
+                .enabled(Box::new(enclose! { (selection) move || selection.borrow().is_some() }))
+                .handler(Box::new(enclose! { (chosen) move || *chosen.borrow_mut() = true })),
         )?;
         let cash_out_button = Button::text(
             SDLPoint::new(475, 625),
@@ -88,8 +89,7 @@ impl RewardScene {
             text_renderer,
             true,
             true,
-            None,
-            Some(Box::new(enclose! { (selection) move || *selection.borrow_mut() = Some(3)})),
+            ButtonDelegate::init().handler(Box::new(enclose! { (selection) move || *selection.borrow_mut() = Some(3)})),
         )?;
         Ok(RewardScene {
             text_renderer: Rc::clone(text_renderer),

--- a/src/intermission/reward_scene.rs
+++ b/src/intermission/reward_scene.rs
@@ -13,7 +13,7 @@ use crate::atlas::prelude::*;
 use crate::clash::{EquipmentItem, EquipmentResource, ProgressionComponent, RewardsComponent};
 use crate::conductor::{Scene, StageDirection};
 use crate::enclose;
-use crate::props::{Button, ButtonDelegate, View};
+use crate::props::{Button, ButtonDelegate, ButtonEnabledState, View};
 
 pub struct RewardScene {
     text_renderer: Rc<TextRenderer>,
@@ -79,9 +79,16 @@ impl RewardScene {
             true,
             true,
             ButtonDelegate::init()
-                .enabled(Box::new(enclose! { (selection) move || selection.borrow().is_some() }))
+                .enabled(Box::new(enclose! { (selection) move ||
+                    if selection.borrow().is_some() {
+                        ButtonEnabledState::Shown
+                    } else {
+                        ButtonEnabledState::Hide
+                    }
+                }))
                 .handler(Box::new(enclose! { (chosen) move || *chosen.borrow_mut() = true })),
         )?;
+
         let cash_out_button = Button::text(
             SDLPoint::new(475, 625),
             &format!("Pass (+{} Influence)", reward.cashout_influence),

--- a/src/intermission/reward_scene.rs
+++ b/src/intermission/reward_scene.rs
@@ -33,7 +33,7 @@ pub fn get_reward(ecs: &World) -> RewardsComponent {
     (&rewards).join().next().unwrap().clone()
 }
 
-pub fn icons_for_items(render_context: &RenderContext, items: &Vec<EquipmentItem>) -> BoxResult<Rc<IconCache>> {
+pub fn icons_for_items(render_context: &RenderContext, items: &[EquipmentItem]) -> BoxResult<Rc<IconCache>> {
     let icons: Vec<&String> = items.iter().flat_map(|i| &i.image).collect();
     Ok(Rc::new(IconCache::init(&render_context, IconLoader::init_icons(), &icons[..])?))
 }

--- a/src/intermission/reward_scene.rs
+++ b/src/intermission/reward_scene.rs
@@ -82,8 +82,6 @@ impl RewardScene {
             "Accept",
             &render_context,
             text_renderer,
-            true,
-            true,
             ButtonDelegate::init()
                 .enabled(Box::new(enclose! { (selection) move |_|
                     if selection.borrow().is_some() {
@@ -100,8 +98,6 @@ impl RewardScene {
             &format!("Pass (+{} Influence)", reward.cashout_influence),
             &render_context,
             text_renderer,
-            true,
-            true,
             ButtonDelegate::init().handler(Box::new(enclose! { (selection) move |_| *selection.borrow_mut() = Some(3)})),
         )?;
         Ok(RewardScene {

--- a/src/intermission/reward_scene.rs
+++ b/src/intermission/reward_scene.rs
@@ -78,7 +78,7 @@ impl RewardScene {
         let chosen = Rc::new(RefCell::new(false));
         let selection = Rc::new(RefCell::new(None));
         let accept_button = Button::text(
-            SDLPoint::new(780, 585),
+            SDLPoint::new(800, 650),
             "Accept",
             &render_context,
             text_renderer,

--- a/src/intermission/reward_scene.rs
+++ b/src/intermission/reward_scene.rs
@@ -5,6 +5,7 @@ use sdl2::keyboard::{Keycode, Mod};
 use sdl2::mouse::MouseButton;
 use sdl2::pixels::Color;
 use sdl2::rect::Point as SDLPoint;
+use sdl2::rect::Rect as SDLRect;
 use specs::prelude::*;
 
 use super::card_view::{CardView, CARD_WIDTH};
@@ -128,6 +129,15 @@ impl RewardScene {
     }
 }
 
+pub fn draw_selection_frame(canvas: &mut RenderCanvas, icons: &IconCache, mut selection_frame: SDLRect, image: &str) -> BoxResult<()> {
+    selection_frame.offset(-2, -2);
+    selection_frame.set_width(selection_frame.width() + 4);
+    selection_frame.set_height(selection_frame.height() + 4);
+    canvas.copy(icons.get(image), None, selection_frame)?;
+
+    Ok(())
+}
+
 impl Scene for RewardScene {
     fn handle_key(&mut self, _keycode: Keycode, _keymod: Mod) {}
 
@@ -149,15 +159,12 @@ impl Scene for RewardScene {
         canvas.copy(self.ui.get("reward_background.png"), None, None)?;
 
         if let Some(selection) = *self.selection.borrow() {
-            let (mut selection_frame, image) = if selection < 3 {
+            let (selection_frame, image) = if selection < 3 {
                 (self.cards[selection as usize].frame, "card_frame_large_selection.png")
             } else {
                 (self.cash_out_button.frame, "button_frame_full_selection.png")
             };
-            selection_frame.offset(-2, -2);
-            selection_frame.set_width(selection_frame.width() + 4);
-            selection_frame.set_height(selection_frame.height() + 4);
-            canvas.copy(self.ui.get(image), None, selection_frame)?;
+            draw_selection_frame(canvas, &self.ui, selection_frame, image)?;
         }
 
         for c in &self.cards {

--- a/src/intermission/reward_scene.rs
+++ b/src/intermission/reward_scene.rs
@@ -99,7 +99,8 @@ impl RewardScene {
             &render_context,
             text_renderer,
             ButtonDelegate::init().handler(Box::new(enclose! { (selection) move |_| *selection.borrow_mut() = Some(3)})),
-        )?;
+        )?
+        .with_size(FontSize::Small);
         Ok(RewardScene {
             text_renderer: Rc::clone(text_renderer),
             ui,

--- a/src/intermission/reward_scene.rs
+++ b/src/intermission/reward_scene.rs
@@ -156,12 +156,11 @@ impl Scene for RewardScene {
         canvas.copy(self.ui.get("reward_background.png"), None, None)?;
 
         if let Some(selection) = *self.selection.borrow() {
-            let (selection_frame, image) = if selection < 3 {
-                (self.cards[selection as usize].frame, "card_frame_large_selection.png")
+            if selection < 3 {
+                draw_selection_frame(canvas, &self.ui, self.cards[selection as usize].frame, "card_frame_large_selection.png")?;
             } else {
-                (self.cash_out_button.frame, "button_frame_full_selection.png")
+                draw_selection_frame(canvas, &self.ui, self.cash_out_button.frame, "button_frame_full_selection.png")?;
             };
-            draw_selection_frame(canvas, &self.ui, selection_frame, image)?;
         }
 
         for c in &self.cards {

--- a/src/intermission/reward_scene.rs
+++ b/src/intermission/reward_scene.rs
@@ -85,7 +85,7 @@ impl RewardScene {
             true,
             true,
             ButtonDelegate::init()
-                .enabled(Box::new(enclose! { (selection) move ||
+                .enabled(Box::new(enclose! { (selection) move |_|
                     if selection.borrow().is_some() {
                         ButtonEnabledState::Shown
                     } else {

--- a/src/intermission/skilltree_view.rs
+++ b/src/intermission/skilltree_view.rs
@@ -154,7 +154,7 @@ impl View for SkillTreeView {
         Ok(())
     }
 
-    fn handle_mouse_click(&mut self, ecs: &World, x: i32, y: i32, button: Option<MouseButton>) {
+    fn handle_mouse_click(&mut self, ecs: &mut World, x: i32, y: i32, button: Option<MouseButton>) {
         if let Some(button) = button {
             if button == MouseButton::Left {
                 if let Some(hit) = self.find_node_at(ecs, x, y) {

--- a/src/intermission/skilltree_view.rs
+++ b/src/intermission/skilltree_view.rs
@@ -167,7 +167,7 @@ impl View for SkillTreeView {
 
     fn hit_test(&self, ecs: &World, x: i32, y: i32) -> Option<HitTestResult> {
         if let Some(hit) = self.find_node_at(ecs, x, y) {
-            Some(HitTestResult::Skill(hit.name().to_string()))
+            Some(HitTestResult::Skill(hit.name()))
         } else {
             None
         }

--- a/src/intermission/skilltree_view.rs
+++ b/src/intermission/skilltree_view.rs
@@ -119,8 +119,8 @@ impl View for SkillTreeView {
         }
 
         for d in dependencies {
-            let left = all.iter().map(|a| &a.0).find(|a| a.name() == &d.0).unwrap();
-            let right = all.iter().map(|a| &a.0).find(|a| a.name() == &d.1).unwrap();
+            let left = all.iter().map(|a| &a.0).find(|a| a.name() == d.0).unwrap();
+            let right = all.iter().map(|a| &a.0).find(|a| a.name() == d.1).unwrap();
 
             if progression.items.contains(&d.0) {
                 canvas.set_draw_color(Color::from((218, 218, 218)));

--- a/src/props.rs
+++ b/src/props.rs
@@ -29,7 +29,7 @@ pub trait View {
     fn hit_test(&self, _ecs: &World, _x: i32, _y: i32) -> Option<HitTestResult> {
         None
     }
-    fn handle_mouse_click(&mut self, _ecs: &World, _x: i32, _y: i32, _button: Option<MouseButton>) {}
+    fn handle_mouse_click(&mut self, _ecs: &mut World, _x: i32, _y: i32, _button: Option<MouseButton>) {}
 
     fn handle_mouse_move(&mut self, _ecs: &World, _x: i32, _y: i32, _state: MouseState) {}
 }

--- a/src/props/help_popup.rs
+++ b/src/props/help_popup.rs
@@ -178,7 +178,7 @@ impl HelpPopup {
         false
     }
 
-    pub fn handle_mouse_click(&mut self, ecs: &World, x: i32, y: i32, button: Option<MouseButton>) {
+    pub fn handle_mouse_click(&mut self, ecs: &mut World, x: i32, y: i32, button: Option<MouseButton>) {
         match self.state {
             HelpPopupState::Tooltip { .. } => {
                 if let Some(button) = button {
@@ -289,7 +289,7 @@ impl HelpPopup {
         }
     }
 
-    pub fn handle_mouse_event(&mut self, ecs: &World, x: i32, y: i32, button: Option<MouseButton>, views: &[Box<dyn View>]) -> bool {
+    pub fn handle_mouse_event(&mut self, ecs: &mut World, x: i32, y: i32, button: Option<MouseButton>, views: &[Box<dyn View>]) -> bool {
         self.handle_mouse_click(ecs, x, y, button);
         // Prevent stray clicks from passing through
         if self.is_enabled() {

--- a/src/props/views.rs
+++ b/src/props/views.rs
@@ -98,7 +98,7 @@ pub enum ButtonEnabledState {
     Hide,
 }
 
-pub type ButtonEnabled = Box<dyn Fn() -> ButtonEnabledState>;
+pub type ButtonEnabled = Box<dyn Fn(&World) -> ButtonEnabledState>;
 pub type ButtonHandler = Box<dyn Fn(&mut World)>;
 
 pub struct ButtonDelegate {
@@ -121,8 +121,8 @@ impl ButtonDelegate {
         self
     }
 
-    pub fn enabled_state(&self) -> ButtonEnabledState {
-        self.enabled.as_ref().map_or(ButtonEnabledState::Shown, |e| (e)())
+    pub fn enabled_state(&self, ecs: &World) -> ButtonEnabledState {
+        self.enabled.as_ref().map_or(ButtonEnabledState::Shown, |e| (e)(ecs))
     }
 }
 
@@ -159,7 +159,7 @@ impl Button {
 
 impl View for Button {
     fn render(&self, ecs: &World, canvas: &mut RenderCanvas, frame: u64) -> BoxResult<()> {
-        let enable_state = self.delegate.enabled_state();
+        let enable_state = self.delegate.enabled_state(ecs);
         if enable_state == ButtonEnabledState::Hide {
             return Ok(());
         }
@@ -189,7 +189,7 @@ impl View for Button {
     }
 
     fn handle_mouse_click(&mut self, ecs: &mut World, x: i32, y: i32, button: Option<MouseButton>) {
-        if self.delegate.enabled_state() == ButtonEnabledState::Hide {
+        if self.delegate.enabled_state(ecs) == ButtonEnabledState::Hide {
             return;
         }
 
@@ -204,8 +204,8 @@ impl View for Button {
         }
     }
 
-    fn hit_test(&self, _ecs: &World, x: i32, y: i32) -> Option<HitTestResult> {
-        if self.delegate.enabled_state() == ButtonEnabledState::Hide {
+    fn hit_test(&self, ecs: &World, x: i32, y: i32) -> Option<HitTestResult> {
+        if self.delegate.enabled_state(ecs) == ButtonEnabledState::Hide {
             return None;
         }
 

--- a/src/props/views.rs
+++ b/src/props/views.rs
@@ -99,7 +99,7 @@ pub enum ButtonEnabledState {
 }
 
 pub type ButtonEnabled = Box<dyn Fn() -> ButtonEnabledState>;
-pub type ButtonHandler = Box<dyn Fn()>;
+pub type ButtonHandler = Box<dyn Fn(&mut World)>;
 
 pub struct ButtonDelegate {
     enabled: Option<ButtonEnabled>,
@@ -188,7 +188,7 @@ impl View for Button {
         Ok(())
     }
 
-    fn handle_mouse_click(&mut self, _ecs: &World, x: i32, y: i32, button: Option<MouseButton>) {
+    fn handle_mouse_click(&mut self, ecs: &mut World, x: i32, y: i32, button: Option<MouseButton>) {
         if self.delegate.enabled_state() == ButtonEnabledState::Hide {
             return;
         }
@@ -197,7 +197,7 @@ impl View for Button {
             if button == MouseButton::Left {
                 if self.frame.contains_point(SDLPoint::new(x, y)) {
                     if let Some(handler) = &self.delegate.handler {
-                        (handler)();
+                        (handler)(ecs);
                     }
                 }
             }
@@ -278,7 +278,7 @@ impl View for TabView {
         Ok(())
     }
 
-    fn handle_mouse_click(&mut self, ecs: &World, x: i32, y: i32, button: Option<MouseButton>) {
+    fn handle_mouse_click(&mut self, ecs: &mut World, x: i32, y: i32, button: Option<MouseButton>) {
         if let Some(button) = button {
             if button == MouseButton::Left {
                 let tab_hit = self.tabs.iter().enumerate().filter_map(|(i, (b, _))| b.hit_test(ecs, x, y).map(|_| i)).next();

--- a/src/props/views.rs
+++ b/src/props/views.rs
@@ -14,6 +14,7 @@ use crate::props::{HitTestResult, View};
 
 pub struct EmptyView {}
 
+#[allow(dead_code)]
 impl EmptyView {
     pub fn init() -> BoxResult<EmptyView> {
         Ok(EmptyView {})


### PR DESCRIPTION
- Implement Merchant tab, where you can spend influence for cards and equipment slots
- Add skill tree nodes to expand equipment slots as well
- Add next battle tab and move next button there.
- Dynamically create equipment slots as they can change from Profession/Merchant choices
- Add new ButtonDelegate to reduce Button ctor madness
- Some Button and Tab API simplifications